### PR TITLE
Menu generation using Content file instead directories

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -48,16 +48,32 @@
                 {{ if and (not .Params.chapter) (.Params.toc) }}
                 <span id="toc-menu"><a href=""><i class="fa fa-list-alt"></i></a></span>
                 {{ end }}
-                {{ $type := .Type }}
-                {{ $relLink := .RelPermalink }}
-                {{ range $name , $value := .Site.Sections }}
-                  {{ if eq $name $type }}
-                    {{ $first := (index $value 0).Page }}
-                    {{ if ne $first.RelPermalink $relLink }}
-                <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
+                 {{ if $page.Site.Params.createFromSiteMenusMain}}
+                    {{ $type := .Params.menu.main.parent }}
+                    {{ $relLink := .RelPermalink }}
+                    {{ range $name , $value := .Site.Menus.main }}
+
+                        {{ if eq $value.Identifier $type }} 
+                          {{ if ne $relLink $value.URL }}
+                               <a href="{{  $value.URL }}" itemprop="url"><span itemprop="title"> <b>{{  $value.Name }}</b></span></a> <i class="fa fa-angle-right"></i>
+                          {{ end }}
+                        {{ end }}
                     {{ end }}
-                  {{ end }}
-                {{ end }}
+                 
+                 {{else}} <!-- use current method as default-->
+                
+                      {{ $type := .Type }}
+                      {{ $relLink := .RelPermalink }}
+                      {{ range $name , $value := .Site.Sections }}
+                        {{ if eq $name $type }}
+                          {{ $first := (index $value 0).Page }}
+                          {{ if ne $first.RelPermalink $relLink }}
+                      <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
+                          {{ end }}
+                        {{ end }}
+                      {{ end }}
+                 {{end}}
+                
                 {{ with .Title }}<span itemprop="title"> {{ . }}</span>{{ end }}
               </div>
               {{ if .Params.toc }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -16,6 +16,42 @@
   <div class="highlightable">
     <ul class="topics">
       {{ $page := . }}
+      
+ {{ if $page.Site.Params.createFromSiteMenusMain}}
+    {{ range .Site.Menus.main }}
+        <li class="dd-item  {{ if eq $page.RelPermalink .URL }}active{{ end }} {{if in $page.RelPermalink .URL }}parent{{ end }}" data-nav-id="{{.URL}}">
+          <a href="{{.URL}}">
+            <span>{{ .Pre  }} {{ .Name }} {{ if $page.Site.Params.showVisitedLinks}}  <i class="fa fa-check read-icon"> {{ end }} </i> </span>
+          </a>
+          {{ if .HasChildren }}
+          <ul>
+            {{ range $lvl2 := .Children}}
+            <li class="dd-item {{ if eq $page.RelPermalink $lvl2.URL }}active{{ end }}" data-nav-id="{{$lvl2.URL}}">
+              <a href="{{$lvl2.URL}}">
+                <span> {{  $lvl2.Pre  }} {{ $lvl2.Name  }} {{ if $page.Site.Params.showVisitedLinks}} <i class="fa fa-check read-icon"></i> {{ end }} </span>
+              </a>
+
+              {{ if $lvl2.HasChildren }}
+              <!-- if children has children 3rd level -->
+              <ul>
+                {{ range $lvl3 := $lvl2.Children}}
+                <li class="dd-item {{ if eq $page.RelPermalink $lvl3.URL }}active{{ end }}" data-nav-id="{{$lvl3.URL}}">
+                  <a href="{{$lvl3.URL}}">
+                    <span>{{  $lvl3.Pre  }} {{ $lvl3.Name  }}    {{ if $page.Site.Params.showVisitedLinks}}  <i class="fa fa-check read-icon"></i> {{ end }} </span>
+                  </a>
+                </li>
+                {{ end }}
+              </ul>
+              {{ end }}
+            </li>
+            {{ end }}
+          </ul>
+          {{ end }}
+        </li>
+    {{ end }}
+ {{else}}
+<!-- Use default method, create menu from folder structure -->
+    
       {{ range $key , $value := .Site.Sections }}
       {{ if ne $key "" }}
       {{ $first := (index $value 0).Page }}
@@ -48,6 +84,11 @@
       </li>
       {{ end }}
       {{ end }}
+      
+     {{ end }}
+      
+      
+      
     </ul>
     <hr>
      {{ if .Site.Params.showVisitedLinks}} 


### PR DESCRIPTION
This implementation use the sample i posted on #2 with a few changes:

#### keep compatibility with current versions

only activated when 

`createFromSiteMenusMain = true `

on `config.toml`

#### Feature  a 3rd Level menu:

![capture](https://cloud.githubusercontent.com/assets/3844166/15559134/7a119660-22d7-11e6-97e4-21f061e839e7.JPG)


### TODO

Need to add to the archetypes the correct information to create the menu, need suggestions on how we change this.

we can create them on the content page

chapter.md
```yaml
--- 
title : "Title to show"
prev: /prev/path
next: /next/path
chapter: true 
menu:
  main:
    identifier : "Unique_ID_OF_PAGE"
    weight: 5
    name : "Title to show"
    pre : '<b>1.</b>'
---
```
 
default.md

```yaml
---
title: What is this Hugo theme ?
prev: /prev/path
next: /next/path
menu:
  main:
    identifier : "Unique_ID_OF_PAGE"
    parent: 'Unique_ID_OF_PARENT'
    weight: 5
    name : "What is this Hugo theme"
---

```

or on the config.toml 
```yaml
--- 
menu:
  main:
      - Name: "about hugo"
        Pre: "<i class='fa fa-heart'></i>"
        Weight: -110
        Identifier: "about"
        URL: "/about/"
      - Name: "getting started"
        Pre: "<i class='fa fa-road'></i>"
        Weight: -100
        URL: "/getting-started/"
---
```
what do you think?

Regards,
André

