### PR TITLE
Fix URL for 'Edit this page' on Windows

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,7 +34,7 @@
                 {{ $Site := .Site }}
                 {{with $File.Path }}
               <div id="top-github-link">
-                  <a class="github-link" href="{{ $Site.Params.editURL }}{{ $File.Dir }}{{ $File.LogicalName }}" target="blank">
+                  <a class="github-link" href="{{ $Site.Params.editURL }}{{ replace $File.Dir "\\" "/" }}{{ $File.LogicalName }}" target="blank">
                     <i class="fa fa-code-fork"></i>
                     Edit this page
                   </a>


### PR DESCRIPTION
Hugo on Windows returns backslash (`\`) instead of forward slash (`/`) for file paths. This fixes the computed URL to edit a page.