### PR TITLE
Extracted menu footer content to separate partial file

### DIFF
--- a/layouts/partials/menu-footer.html
+++ b/layouts/partials/menu-footer.html
@@ -1,0 +1,1 @@
+<p>Built with <a href="https://github.com/matcornic/hugo-theme-learn"><i class="fa fa-heart"></i></a> from <a href="http://getgrav.org">Grav</a> and <a href="http://gohugo.io/">Hugo</a></p>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -72,7 +72,7 @@
      <a class="padding" href="#" data-clear-history-toggle=""><i class="fa fa-fw fa-history"></i> Clear History</a>
      {{ end }}
     <section id="footer">
-      <p>Built with <a href="https://github.com/matcornic/hugo-theme-learn"><i class="fa fa-heart"></i></a> from <a href="http://getgrav.org">Grav</a> and <a href="http://gohugo.io/">Hugo</a></p>
+      {{ partial "menu-footer.html" . }}
     </section>
   </div>
 </nav>


### PR DESCRIPTION
Extracted menu footer content to separate partial file named ``menu-footer.html``, so this easily can be changed or overwritten without the need to overwrite the entire ``menu.html`` file.

```html
<section id="footer">
    {{ partial "menu-footer.html" . }}
</section>
```