### PR TITLE
Use index pages + automatic navigation arrows

### DIFF
--- a/archetypes/chapter.md
+++ b/archetypes/chapter.md
@@ -1,9 +1,6 @@
 ---
 title: "Some Chapter title"
 weight: 0
-prev: /prev/path
-next: /next/path
-chapter: true
 icon: "<b>X. </b>" # HTML code as prefix in the menu
 ---
 

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,8 +1,6 @@
 ---
 title: "Some Title"
 weight: 5
-prev: /prev/path
-next: /next/path
 toc: true
 ---
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,3 @@
+{{ partial "header.html" . }}
+{{ .Content }}
+{{ partial "footer.html" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,10 +1,13 @@
-{{ partial "header.html" . }}
 {{ if .Content }}
+{{ partial "header.html" . }}
 {{ .Content }}
-{{ else }}
-{{ with (index (index .Site.Sections .Section) 0)  }}
-{{ .Page.Content }}
-{{ $.Scratch.Set "uniqueId" .Page.UniqueID }}
-{{ end }}
-{{ end }}
 {{ partial "footer.html" . }}
+{{ else }}
+{{ with (index (index .Site.Sections .Section) 0) }}
+{{ with .Page }}
+{{ partial "header.html" . }}
+{{ .Content }}
+{{ partial "footer.html" . }}
+{{ end }}
+{{ end }}
+{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,9 @@
-{{ if .Content }}
 {{ partial "header.html" . }}
+{{ if .Content }}
 {{ .Content }}
-{{ partial "footer.html" . }}
+{{ else }}
+{{ with (index (index .Site.Sections .Section) 0)  }}
+{{ .Page.Content }}
 {{ end }}
+{{ end }}
+{{ partial "footer.html" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,6 +4,7 @@
 {{ else }}
 {{ with (index (index .Site.Sections .Section) 0)  }}
 {{ .Page.Content }}
+{{ $.Scratch.Set "uniqueId" .Page.UniqueID }}
 {{ end }}
 {{ end }}
 {{ partial "footer.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 
-      {{ if .Params.chapter }}
+      {{ if eq .Kind "section" }}
         </div> <!-- end chapter-->
       {{ end }}
       </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,6 +6,7 @@
       </div>
     </div>
 
+    {{ if $.Site.Params.autoNav }}
     {{ $.Scratch.Set "_sectionpages" (slice) }}
     {{ if $.Site.Params.menu }}
       {{ range $sname := $.Site.Params.menu }}
@@ -26,11 +27,14 @@
         {{ $.Scratch.Add "_allpages" .Page }}
       {{ end }}
     {{ end }}
-    {{ $allpages := $.Scratch.Get "_allpages" }}
+    {{ end }}
 
     <div id="navigation">
+        {{ if $.Site.Params.autoNav }}
+        {{ $allpages := $.Scratch.Get "_allpages" }}
         {{ range $index, $element := $allpages }}
-          {{if eq $element.UniqueID $.UniqueID }}
+          {{ $uniqueid := ($.Scratch.Get "uniqueId" | default $.UniqueID ) }}
+          {{if eq $element.UniqueID $uniqueid }}
             {{ if not (isset $.Params "prev") }}
               {{ with index $allpages (sub $index 1) }}
                 <a class="nav nav-prev" href="{{ $.Site.BaseURL }}{{ .URL }}"> <i class="fa fa-chevron-left"></i></a>
@@ -42,6 +46,7 @@
               {{ end }}
             {{ end }}
           {{ end }}
+        {{ end }}
         {{ end }}
         {{ with .Params.prev }}<a class="nav nav-prev" href="{{ $.Site.BaseURL }}{{ . }}"> <i class="fa fa-chevron-left"></i></a>{{ end }}
         {{ with .Params.next }}<a class="nav nav-next" href="{{ $.Site.BaseURL }}{{ . }}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -37,12 +37,12 @@
           {{if eq $element.UniqueID $uniqueid }}
             {{ if not (isset $.Params "prev") }}
               {{ with index $allpages (sub $index 1) }}
-                <a class="nav nav-prev" href="{{ $.Site.BaseURL }}{{ .URL }}"> <i class="fa fa-chevron-left"></i></a>
+                <a class="nav nav-prev" href="{{ .URL }}"> <i class="fa fa-chevron-left"></i></a>
               {{ end }}
             {{ end }}
             {{ if not (isset $.Params "next") }}
               {{ with index $allpages (add $index 1) }}
-                <a class="nav nav-next" href="{{ $.Site.BaseURL }}{{ .URL }}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>
+                <a class="nav nav-next" href="{{ .URL }}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>
               {{ end }}
             {{ end }}
           {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 
-      {{ $isChapter := or (eq .Kind "section") (.Params.chapter)}}
+      {{ $isChapter := .Params.chapter | default (eq .Kind "section")}}
       {{ if $isChapter }}
         </div> <!-- end chapter-->
       {{ end }}
@@ -33,8 +33,7 @@
         {{ if $.Site.Params.autoNav }}
         {{ $allpages := $.Scratch.Get "_allpages" }}
         {{ range $index, $element := $allpages }}
-          {{ $uniqueid := ($.Scratch.Get "uniqueId" | default $.UniqueID ) }}
-          {{if eq $element.UniqueID $uniqueid }}
+          {{if eq $element.UniqueID $.UniqueID }}
             {{ if not (isset $.Params "prev") }}
               {{ with index $allpages (sub $index 1) }}
                 <a class="nav nav-prev" href="{{ .URL }}"> <i class="fa fa-chevron-left"></i></a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,10 +5,46 @@
       </div>
     </div>
 
+    {{ with .Site.Params.menu }}
+      {{ range $index, $element := . }}
+        {{ with index $.Site.Params.menu (sub $index 1)}}
+          {{ $prev := index (last 1 (index $.Site.Sections .)) 0 }}
+          {{ $.Scratch.SetInMap $element "prev" $prev }}
+        {{ end }}
+        {{ with index $.Site.Params.menu (add $index 1)}}
+          {{ $next := index (first 1 (index $.Site.Sections .)) 0 }}
+          {{ $.Scratch.SetInMap $element "next" $next }}
+        {{ end }}
+      {{ end }}
+    {{ else }}
+      {{ range $key, $section := $.Site.Sections }}
+        {{ with $prevSec := $.Scratch.Get "prevIter"}}
+          {{ with index $.Site.Sections . }}
+            {{ $.Scratch.SetInMap $key "prev" (index (last 1 .) 0) }}
+            {{ $.Scratch.SetInMap $prevSec "next" (index (first 1 $section) 0) }}
+          {{ end }}
+        {{ end }}
+        {{ $.Scratch.Set "prevIter" $key }}
+      {{ end }}
+    {{ end }}
     <div id="navigation">
-        {{ $Site := .Site }}
-        {{ with .Params.prev }}<a class="nav nav-prev" href="{{ $Site.BaseURL }}{{ . }}"> <i class="fa fa-chevron-left"></i></a>{{ end }}
-        {{ with .Params.next }}<a class="nav nav-next" href="{{ $Site.BaseURL }}{{ . }}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>{{ end }}
+        {{ $secpages := sort (where .Site.RegularPages "Section" .Section) "Weight" }}
+        {{ range $index, $element := $secpages }}
+          {{if eq $element.UniqueID $.UniqueID }}
+            {{ if not (isset $.Params "prev") }}
+              {{ with index $secpages (sub $index 1) | default ($.Scratch.Get $.Section).prev.Page}}
+                <a class="nav nav-prev" href="{{ $.Site.BaseURL }}{{ .URL }}"> <i class="fa fa-chevron-left"></i></a>
+              {{ end }}
+            {{ end }}
+            {{ if not (isset $.Params "next") }}
+              {{ with index $secpages (add $index 1) | default ($.Scratch.Get $.Section).next.Page}}
+                <a class="nav nav-next" href="{{ $.Site.BaseURL }}{{ .URL }}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>
+              {{ end }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+        {{ with .Params.prev }}<a class="nav nav-prev" href="{{ $.Site.BaseURL }}{{ . }}"> <i class="fa fa-chevron-left"></i></a>{{ end }}
+        {{ with .Params.next }}<a class="nav nav-next" href="{{ $.Site.BaseURL }}{{ . }}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>{{ end }}
     </div>
 
     </section>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,39 +5,29 @@
       </div>
     </div>
 
-    {{ with .Site.Params.menu }}
-      {{ range $index, $element := . }}
-        {{ with index $.Site.Params.menu (sub $index 1)}}
-          {{ $prev := index (last 1 (index $.Site.Sections .)) 0 }}
-          {{ $.Scratch.SetInMap $element "prev" $prev }}
-        {{ end }}
-        {{ with index $.Site.Params.menu (add $index 1)}}
-          {{ $next := index (first 1 (index $.Site.Sections .)) 0 }}
-          {{ $.Scratch.SetInMap $element "next" $next }}
-        {{ end }}
-      {{ end }}
-    {{ else }}
-      {{ range $key, $section := $.Site.Sections }}
-        {{ with $prevSec := $.Scratch.Get "prevIter"}}
-          {{ with index $.Site.Sections . }}
-            {{ $.Scratch.SetInMap $key "prev" (index (last 1 .) 0) }}
-            {{ $.Scratch.SetInMap $prevSec "next" (index (first 1 $section) 0) }}
-          {{ end }}
-        {{ end }}
-        {{ $.Scratch.Set "prevIter" $key }}
+    {{ $.Scratch.Set "_sectionpages" (slice) }}
+    {{ range $sname, $spages := .Site.Sections }}
+      {{ $.Scratch.Add "_sectionpages" ($.Site.GetPage "section" $sname) }}
+    {{ end }}
+    {{ $.Scratch.Set "_allpages" (slice) }}
+    {{ range sort ($.Scratch.Get "_sectionpages") "Weight" }}
+      {{ $.Scratch.Add "_allpages" . }}
+      {{ range index $.Site.Sections .Section }}
+        {{ $.Scratch.Add "_allpages" .Page }}
       {{ end }}
     {{ end }}
+    {{ $allpages := $.Scratch.Get "_allpages" }}
+
     <div id="navigation">
-        {{ $secpages := sort (where .Site.RegularPages "Section" .Section) "Weight" }}
-        {{ range $index, $element := $secpages }}
+        {{ range $index, $element := $allpages }}
           {{if eq $element.UniqueID $.UniqueID }}
             {{ if not (isset $.Params "prev") }}
-              {{ with index $secpages (sub $index 1) | default ($.Scratch.Get $.Section).prev.Page}}
+              {{ with index $allpages (sub $index 1) }}
                 <a class="nav nav-prev" href="{{ $.Site.BaseURL }}{{ .URL }}"> <i class="fa fa-chevron-left"></i></a>
               {{ end }}
             {{ end }}
             {{ if not (isset $.Params "next") }}
-              {{ with index $secpages (add $index 1) | default ($.Scratch.Get $.Section).next.Page}}
+              {{ with index $allpages (add $index 1) }}
                 <a class="nav nav-next" href="{{ $.Site.BaseURL }}{{ .URL }}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>
               {{ end }}
             {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -47,7 +47,7 @@
                         <i class="fa fa-bars"></i>
                       </a>
                   </span>
-                {{ if and (not .Params.chapter) (.Params.toc) }}
+                {{ if and (ne .Kind "section") (.Params.toc) }}
                 <span id="toc-menu"><a href=""><i class="fa fa-list-alt"></i></a></span>
                 {{ end }}
                 {{ $type := .Type }}
@@ -67,10 +67,10 @@
               {{ end }}
 
             </div>
-            {{ if .Params.chapter }}
+            {{ if eq .Kind "section" }}
               <div id="chapter">
             {{ end }}
-    	        <div id="body-inner">
-                {{ if not .Params.chapter }}
+              <div id="body-inner">
+                {{ if ne .Kind "section" }}
                 <h1>{{.Title}}</h1>
                 {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -22,7 +22,7 @@
     {{ partial "style.html" . }}
   </head>
   <body class="" data-url="{{ .RelPermalink }}">
-    {{ $isChapter := or (eq .Kind "section") (.Params.chapter)}}
+    {{ $isChapter := .Params.chapter | default (eq .Kind "section")}}
     {{ partial "menu.html" . }}
         <section id="body">
         <div id="overlay"></div>
@@ -51,14 +51,17 @@
                 {{ if and (not $isChapter) (.Params.toc) }}
                 <span id="toc-menu"><a href=""><i class="fa fa-list-alt"></i></a></span>
                 {{ end }}
-                {{ $type := .Type }}
-                {{ $relLink := .RelPermalink }}
-                {{ range $name , $value := .Site.Sections }}
-                  {{ if eq $name $type }}
-                    {{ $first := (index $value 0).Page }}
-                    {{ if ne $first.RelPermalink $relLink }}
-                <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
-                    {{ end }}
+                {{ $section := index .Site.Sections .Section }}
+                {{ $sectionPage := $.Site.GetPage "section" $.Section }}
+                {{ if $sectionPage.Content }}
+                  {{ $first := $.Site.GetPage "section" $.Section }}
+                  {{ if ne $first.UniqueID $.UniqueID }}
+              <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
+                  {{ end }}
+                {{ else if gt $section.Len 0 }}
+                  {{ $first := (index $section 0).Page }}
+                  {{ if ne $first.UniqueID $.UniqueID }}
+              <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
                   {{ end }}
                 {{ end }}
                 {{ with .Title }}<span itemprop="title"> {{ . }}</span>{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -51,17 +51,19 @@
                 {{ if and (not $isChapter) (.Params.toc) }}
                 <span id="toc-menu"><a href=""><i class="fa fa-list-alt"></i></a></span>
                 {{ end }}
-                {{ $section := index .Site.Sections .Section }}
-                {{ $sectionPage := $.Site.GetPage "section" $.Section }}
-                {{ if $sectionPage.Content }}
-                  {{ $first := $.Site.GetPage "section" $.Section }}
-                  {{ if ne $first.UniqueID $.UniqueID }}
-              <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
-                  {{ end }}
-                {{ else if gt $section.Len 0 }}
-                  {{ $first := (index $section 0).Page }}
-                  {{ if ne $first.UniqueID $.UniqueID }}
-              <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
+                {{ if ne $.Section "" }}
+                  {{ $section := index $.Site.Sections $.Section }}
+                  {{ $sectionPage := $.Site.GetPage "section" $.Section }}
+                  {{ if $sectionPage.Content }}
+                    {{ $first := $.Site.GetPage "section" $.Section }}
+                    {{ if ne $first.UniqueID $.UniqueID }}
+                <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
+                    {{ end }}
+                  {{ else if gt $section.Len 0 }}
+                    {{ $first := (index $section 0).Page }}
+                    {{ if ne $first.UniqueID $.UniqueID }}
+                <a href="{{ $first.RelPermalink }}" itemprop="url"><span itemprop="title">{{ $first.Title }}</span></a> <i class="fa fa-angle-right"></i>
+                    {{ end }}
                   {{ end }}
                 {{ end }}
                 {{ with .Title }}<span itemprop="title"> {{ . }}</span>{{ end }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -12,31 +12,27 @@
   <div class="highlightable">
     <ul class="topics">
       {{ $page := . }}
-      {{ if .Site.Params.menu }}
-        {{ $.Scratch.Set "menuItems" (slice) }}
-        {{ range $i, $key := .Site.Params.menu }}
-          {{ if isset $page.Site.Sections $key }}
-            {{ $.Scratch.Add "menuItems" $key }}
-          {{ else }}
-            <li class="dd-item"><div class="notices warning"><p>
-            {{ printf "Unknown section '%s' found in site menu" $key }}
-            </p></div></li>
-          {{ end }}
-        {{ end }}
-      {{ else }}
-        {{ $.Scratch.Set "menuItems" .Site.Sections }}
+      {{ $.Scratch.Set "_pages" (slice) }}
+      {{ range $key, $value := .Site.Sections }}
+        {{ $.Scratch.Add "_pages" ($.Site.GetPage "section" $key) }}
+      {{ end }}
+      {{ $.Scratch.Set "menuItems" (slice)}}
+      {{ range $key, $value := sort ($.Scratch.Get "_pages") "Weight" }}
+        {{ $.Scratch.Add "menuItems" $value.Section }}
       {{ end }}
       {{ $menuItems := $.Scratch.Get "menuItems" }}
       {{ range $i, $key := $menuItems }}
       {{ if ne $key "" }}
 
-      {{ if not $.Site.Params.menu }}
-        {{ $.Scratch.Set "currentItem" (index $page.Site.Sections $i) }}
-      {{ else }}
-        {{ $.Scratch.Set "currentItem" (index $page.Site.Sections $key) }}
+      {{ $value := (index $page.Site.Sections $key) }}
+      {{ with $index := $.Site.GetPage "section" $key }}
+        {{ if .Title }}
+          {{ $.Scratch.Set "first" $index }}
+        {{ else }}
+          {{ $.Scratch.Set (index $value 0).Page }}
+        {{ end }}
       {{ end }}
-      {{ $value := $.Scratch.Get "currentItem" }}
-      {{ $first := (index $value 0).Page }}
+      {{ $first := $.Scratch.Get "first" }}
 
       <li class="dd-item {{ if eq $page.RelPermalink $first.RelPermalink }}active{{ end }} {{if in $page.RelPermalink $first.RelPermalink }}parent{{ end }}" data-nav-id="{{ $first.RelPermalink }}">
         <a href="{{ $first.RelPermalink }}">
@@ -50,16 +46,14 @@
              {{ end }}
            </span>
         </a>
-        {{ if gt $value.Len 1}}
+        {{ if gt $value.Len 0}}
         <ul>
           {{ range $k, $p := $value }}
-          {{ if gt $k 0 }}
             <li class="dd-item {{ if eq $page.RelPermalink $p.Page.RelPermalink }}active{{ end }}" data-nav-id="{{ $p.Page.RelPermalink }}">
               <a href="{{ $p.Page.RelPermalink }}">
                 <span>{{ $p.Page.Title }}    {{ if $page.Site.Params.showVisitedLinks}}  <i class="fa fa-check read-icon">  {{ end }} </i></span>
               </a>
             </li>
-          {{ end }}
           {{ end }}
         </ul>
         {{ end }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -26,11 +26,7 @@
 
       {{ $value := (index $page.Site.Sections $key) }}
       {{ with $index := $.Site.GetPage "section" $key }}
-        {{ if .Title }}
-          {{ $.Scratch.Set "first" $index }}
-        {{ else }}
-          {{ $.Scratch.Set (index $value 0).Page }}
-        {{ end }}
+        {{ $.Scratch.Set "first" $index }}
       {{ end }}
       {{ $first := $.Scratch.Get "first" }}
 

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -35,7 +35,11 @@
           {{ $.Scratch.Set "first" $index }}
         {{ else }}
           {{ $.Scratch.Set "first" (index $value 0).Page }}
-          {{ $.Scratch.Set "_value" (after 1 $value) }}
+          {{ if gt $value.Len 1 }}
+            {{ $.Scratch.Set "_value" (after 1 $value) }}
+          {{ else }}
+            {{ $.Scratch.Set "_value" nil }}
+          {{ end }}
         {{ end }}
       {{ end }}
       {{ $first := $.Scratch.Get "first" }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -11,13 +11,17 @@
 
   <div class="highlightable">
     <ul class="topics">
-      {{ $page := . }}
       {{ if $.Site.Params.menu }}
         {{ $.Scratch.Set "menuItems" $.Site.Params.menu }}
       {{ else }}
         {{ $.Scratch.Set "_pages" (slice) }}
         {{ range $key, $value := .Site.Sections }}
-          {{ $.Scratch.Add "_pages" ($.Site.GetPage "section" $key) }}
+          {{ $sectionPage := $.Site.GetPage "section" $key }}
+          {{ if $sectionPage.Content }}
+            {{ $.Scratch.Add "_pages" $sectionPage }}
+          {{ else if gt $value.Len 0 }}
+            {{ $.Scratch.Add "_pages" (index $value 0).Page }}
+          {{ end }}
         {{ end }}
         {{ $.Scratch.Set "menuItems" (slice)}}
         {{ range $key, $value := sort ($.Scratch.Get "_pages") "Weight" }}
@@ -28,12 +32,12 @@
       {{ range $i, $key := $menuItems }}
       {{ if ne $key "" }}
 
-      {{ $value := (index $page.Site.Sections $key) }}
+      {{ $value := (index $.Site.Sections $key) }}
       {{ $.Scratch.Set "_value" $value }}
       {{ with $index := $.Site.GetPage "section" $key }}
         {{ if .Content }}
           {{ $.Scratch.Set "first" $index }}
-        {{ else }}
+        {{ else if gt $value.Len 0}}
           {{ $.Scratch.Set "first" (index $value 0).Page }}
           {{ if gt $value.Len 1 }}
             {{ $.Scratch.Set "_value" (after 1 $value) }}
@@ -45,14 +49,14 @@
       {{ $first := $.Scratch.Get "first" }}
       {{ $value := $.Scratch.Get "_value" }}
 
-      <li class="dd-item {{ if eq $page.RelPermalink $first.RelPermalink }}active{{ end }} {{if in $page.RelPermalink $first.RelPermalink }}parent{{ end }}" data-nav-id="{{ $first.RelPermalink }}">
+      <li class="dd-item {{ if eq $.UniqueID $first.UniqueID }}active{{ end }} {{if eq $.Section $first.Section }}parent{{ end }}" data-nav-id="{{ $first.RelPermalink }}">
         <a href="{{ $first.RelPermalink }}">
           <span>
             {{ if isset $first.Params "icon" }}
               {{ printf $first.Params.icon | safeHTML }}
             {{ end }}
              {{ $first.Title }}
-            {{ if $page.Site.Params.showVisitedLinks}}
+            {{ if $.Site.Params.showVisitedLinks}}
               <i class="fa fa-check read-icon"></i>
              {{ end }}
            </span>
@@ -60,9 +64,9 @@
         {{ if gt $value.Len 0}}
         <ul>
           {{ range $k, $p := $value }}
-            <li class="dd-item {{ if eq $page.RelPermalink $p.Page.RelPermalink }}active{{ end }}" data-nav-id="{{ $p.Page.RelPermalink }}">
+            <li class="dd-item {{ if eq $.UniqueID $p.Page.UniqueID }}active{{ end }}" data-nav-id="{{ $p.Page.RelPermalink }}">
               <a href="{{ $p.Page.RelPermalink }}">
-                <span>{{ $p.Page.Title }}    {{ if $page.Site.Params.showVisitedLinks}}  <i class="fa fa-check read-icon">  {{ end }} </i></span>
+                <span>{{ $p.Page.Title }}    {{ if $.Site.Params.showVisitedLinks}}  <i class="fa fa-check read-icon">  {{ end }} </i></span>
               </a>
             </li>
           {{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ description = "Documentation theme for Hugo, based on Grav Learn theme"
 homepage = "https://matcornic.github.io/hugo-learn-doc/basics/what-is-this-hugo-theme/"
 tags = ["documentation", "grav", "learn", "doc"]
 features = ["documentation"]
-min_version = 0.17
+min_version = 0.19
 
 [author]
   name = "Mathieu Cornic"


### PR DESCRIPTION
This PR enables using `_index.md` pages for chapters and adds automatic generation of navigation arrows (#22). I tried *hard* to keep this backwards-compatible, and it seems to be, for the most part. A caveat is that automatic navigation ~errors~ arrows may not work for legacy structure (with `index.md` pages) 100% of the time (although a hack to *make* it work most of the time is included).

Changes:

* Chapter pages should now be named `_index.md`
* `chapter: true` is unnecessary for `_index.md` files
* New site parameter `autoNav` enables automatic navigation arrows. `prev` and `next` page metadata options are still supported as overrides. Setting `prev: false` or `next: false` disables an arrow on that page.
* `menu` site parameter is superseded by weight-based ordering of `_index.md` pages. Weight of `_index.md` pages works exactly like weight of normal pages, but on chapter level.

All of those changes are recommendatory, i.e. it should still work with old sites just fine.