### PR TITLE
Enable data-search-clear intended functionality.

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,7 +1,7 @@
 <div class="searchbox">
     <label for="search-by"><i class="fa fa-search"></i></label>
     <input id="search-by" type="text" placeholder="Search">
-    <span data-search-clear=""><i class="fa fa-close"></i></span>
+    <span id="data-search-clear" onclick="$('#search-by').val('');"><i class="fa fa-close"></i></span>
 </div>
 <script type="text/javascript" src="{{ .Site.BaseURL }}/js/lunr.min.js"></script>
 <script type="text/javascript" src="{{ .Site.BaseURL }}/js/horsey.js"></script>


### PR DESCRIPTION
Uses the `onclick` event for the data-search-clear `span` to clear the search field value.