### PR TITLE
Fix sticky header jumpiness

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,9 +27,10 @@
         <section id="body">
         <div id="overlay"></div>
 
-        <div class="padding highlightable">
-
-            <div id="top-bar">
+        <div class="padding highlightable sticky-parent">
+            
+            <div class="sticky-spacer">
+              <div id="top-bar">
               {{ if and .IsPage .Site.Params.editURL }}
                 {{ $File := .File }}
                 {{ $Site := .Site }}
@@ -71,6 +72,7 @@
               {{ if .Params.toc }}
                   {{ partial "toc.html" . }}
               {{ end }}
+            </div>
 
             </div>
             {{ if $isChapter }}

--- a/static/js/hugo-learn.js
+++ b/static/js/hugo-learn.js
@@ -56,7 +56,10 @@ images.each(function(index){
 });
 
 // Stick the top to the top of the screen when  scrolling
-$("#top-bar").stick_in_parent({spacer: false});
+$("#top-bar").stick_in_parent( {
+  parent: ".sticky-parent",
+  spacer: ".sticky-spacer",
+});
 
 
 jQuery(document).ready(function() {


### PR DESCRIPTION
When the top bar reaches the top, the heading jumps as the original top-bar is removed from the DOM. (Scroll this page: https://matcornic.github.io/hugo-learn-doc/basics/installation/ for an example). 

This is due to a a slight nuance of how Sticky-Kit works. To prevent this, I have updated the HTML and JS related to the top bar as suggested here: https://github.com/leafo/sticky-kit/wiki/Troubleshooting#my-adsiframeplugin-based-content-flashes-or-get-removed-when-it-becomes-sticky
