### PR TITLE
Remove white space from `align` parameter

### DIFF
--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,1 +1,1 @@
-<div class="mermaid" align="{{ if .Get " align " }}{{ .Get "align " }}{{ else }}center{{ end }}">{{ safeHTML .Inner }}</div>
+<div class="mermaid" align="{{ if .Get "align" }}{{ .Get "align" }}{{ else }}center{{ end }}">{{ safeHTML .Inner }}</div>


### PR DESCRIPTION
Fixes alignment behavior in the short code