### PR TITLE
Add "display" option to the shortcode "expand"

### DIFF
--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,16 +1,16 @@
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fa fa-chevron-down' : 'fa fa-chevron-right';});});">
-        <i style="font-size:x-small;" class="fa fa-chevron-right"></i>
+        <i style="font-size:x-small;" class="fa {{ if .IsNamedParams }}{{ if eq (.Get "display") "true"}}fa-chevron-down{{else}}fa-chevron-right{{end}}{{else}}{{ if eq (.Get 1) "true"}}fa-chevron-down{{else}}fa-chevron-right{{end}}{{end}}"></i>
         <span>
         {{$expandMessage := T "Expand-title"}}
     	{{ if .IsNamedParams }}
     	{{.Get "default" | default $expandMessage}}
     	{{else}}
-    	{{.Get 0 | default $expandMessage}}
-    	{{end}}
+        {{.Get 0 | default $expandMessage}}
+        {{end}}
     	</span>
     </div>
-    <div class="expand-content" style="display: none;">
+    <div class="expand-content" style="{{ if .IsNamedParams }}{{ if eq (.Get "display") "true"}}display: visible;{{else}}display: none;{{end}}{{else}}{{ if eq (.Get 1) "true"}}display: visible;{{else}}display: none;{{end}}{{end}}">
         {{.Inner | safeHTML}}
     </div>
 </div>


### PR DESCRIPTION
Relative to the issue #69, this PR allows shortcode "expand" to be show with "open" state by default if the option "display" is set to true.

eg:

```
{{%expand "Is Open?" %}}No!{{% /expand%}}

{{%expand "Is Open?" true %}}Yes!{{% /expand%}}
```  

Signed-off-by: Thibault Meyer <meyer.thibault@gmail.com>