### PR TITLE
Include all css-files inside a configurable /static/<css> directory

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,7 +21,20 @@
       <link href="{{(printf "css/theme-%s.css" .) | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">
     {{end}}
 
-    <script src="{{"js/jquery-2.x.min.js"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
+
+    {{ $css  := .Site.Params.cssDirectory | default "css" | replaceRE "^/" "" }}
+    {{ $path := printf "/static/%s" $css }}
+
+    {{ if not (fileExists $path) }}
+       {{ errorf "No such directory: %s" $path  }}
+    {{ else }}
+      {{ range (readDir $path) }}
+          {{ $url := printf "%s/%s" $css .Name | relURL }}
+             <link href="{{ $url }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">
+       {{ end }}
+    {{ end }}
+
+       <script src="{{"js/jquery-2.x.min.js"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
     
     <style type="text/css">
       :root #header + #content > #left > #rlblock_left{ 


### PR DESCRIPTION
Thanks for a great Hugo Theme!

I've added support for `.Site.Params.cssDirectory` (default = "css") used to name a directory `<css>` inside `/static`. All files inside `/static/<css>` will automatically be included as `<link href="..." rel="stylesheet">` in the page header.

This is my first attempt at playing around with Hugo templates and there might be better ways of doing this. 