### PR TITLE
Fix: No class highlight for link to footnote

### DIFF
--- a/static/js/learn.js
+++ b/static/js/learn.js
@@ -236,7 +236,7 @@ jQuery(document).ready(function() {
     });
 
     $('#top-bar a:not(:has(img)):not(.btn)').addClass('highlight');
-    $('#body-inner a:not(:has(img)):not(.btn)').addClass('highlight');
+    $('#body-inner a:not(:has(img)):not(.btn):not(a[rel="footnote"])').addClass('highlight');
 
     var touchsupport = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)
     if (!touchsupport){ // browser doesn't support touch


### PR DESCRIPTION
Don't add class `highlight` to links to footnotes. With class `highlight`, for the following Markdown:

    A sentence with a footnote.[^target]

, the footnote may be rendered on the next line, 

![screen shot 2017-11-08 at 00 18 50](https://user-images.githubusercontent.com/8029215/32523174-7926b36c-c41a-11e7-86d5-deba5e8b1784.png)

, due to setting `display: inline-block;`in the following rule in `hugo-theme.css`:

```
#body a.highlight {
    line-height: 1.1;
    display: inline-block;
}
```

When the footnote link don't have the highlight class the footnote number will always be rendered on the same line as the preceding `footnote.`. 

![screen shot 2017-11-08 at 01 35 57](https://user-images.githubusercontent.com/8029215/32525599-7e6df1fe-c425-11e7-8887-bd3637b47044.png)

![screen shot 2017-11-08 at 01 35 49](https://user-images.githubusercontent.com/8029215/32525600-7e8a0d26-c425-11e7-8aeb-1b3dda0e144e.png)
