### PR TITLE
Added a `menuTitle` attribute to partials/menu.html

### DIFF
--- a/exampleSite/content/cont/pages/_index.en.md
+++ b/exampleSite/content/cont/pages/_index.en.md
@@ -98,6 +98,8 @@ Each Hugo page has to define a [Front Matter](https://gohugo.io/content/front-ma
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc = "false"
+# If set, this will be used for the page's menu entry (instead of the `title` attribute)
+menuTitle = ""
 # The title of the page in menu will be prefixed by this HTML content
 pre = ""
 # The title of the page in menu will be postfixed by this HTML content
@@ -136,6 +138,22 @@ The simplest way is to set `weight` parameter to a number.
 +++
 title = "My page"
 weight = 5
++++
+```
+
+### Using a custom title for menu entries
+
+By default, **Hugo-theme-learn** will use a page's `title` attribute for the menu item (or `linkTitle` if defined).
+
+But a page's title has to be descriptive on its own while the menu is a hierarchy.  
+We've added the `menuTitle` parameter for that purpose:
+
+For example (for a page named `content/install/linux.md`): 
+
+```toml
++++
+title = "Install on Linux"
+menuTitle = "Linux"
 +++
 ```
 

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -103,7 +103,7 @@
         {{if .Params.alwaysopen}}parent{{end}}
         ">
       <a href="{{.RelPermalink}}">
-          {{safeHTML .Params.Pre}}{{or .LinkTitle .Title}}{{safeHTML .Params.Post}}
+          {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
           {{ if $showvisitedlinks}}
             <i class="fa fa-check read-icon"></i>
           {{ end }}
@@ -139,7 +139,7 @@
     {{ if not .Params.Hidden }}
       <li data-nav-id="{{.URL}}" title="{{.Title}}" class="dd-item {{if eq .UniqueID $currentNode.UniqueID}}active{{end}}">
         <a href="{{ .RelPermalink}}">
-        {{safeHTML .Params.Pre}}{{or .LinkTitle .Title}}{{safeHTML .Params.Post}}
+        {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
         {{ if $showvisitedlinks}}<i class="fa fa-check read-icon"></i>{{end}}
         </a>
     </li>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -103,7 +103,7 @@
         {{if .Params.alwaysopen}}parent{{end}}
         ">
       <a href="{{.RelPermalink}}">
-          {{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}
+          {{safeHTML .Params.Pre}}{{or .LinkTitle .Title}}{{safeHTML .Params.Post}}
           {{ if $showvisitedlinks}}
             <i class="fa fa-check read-icon"></i>
           {{ end }}
@@ -139,7 +139,7 @@
     {{ if not .Params.Hidden }}
       <li data-nav-id="{{.URL}}" title="{{.Title}}" class="dd-item {{if eq .UniqueID $currentNode.UniqueID}}active{{end}}">
         <a href="{{ .RelPermalink}}">
-        {{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}
+        {{safeHTML .Params.Pre}}{{or .LinkTitle .Title}}{{safeHTML .Params.Post}}
         {{ if $showvisitedlinks}}<i class="fa fa-check read-icon"></i>{{end}}
         </a>
     </li>


### PR DESCRIPTION
Right now the `title` frontmatter argument is used both for the page title and for its entry in the menu hierarchy.

This makes it hard to use descriptive titles. Take the following hierarchy for example:

- Install
  - Linux
  - ...

The `Linux` page would have to use that exact title. A better (and more descriptive) page title would be *Install on Linux* (but that's a little long for the menu).

This patch will use the official `linkTitle` if present.
And if the custom `menuTitle` is defined, that one will be used instead.