### PR TITLE
role="" is invalid

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -31,7 +31,7 @@
         <h3>{{ if not $disableShortcutsTitle}}{{ T "Shortcuts-Title"}}{{ end }}</h3>
         <ul>
           {{ range sort . "Weight"}}
-              <li class="" role=""> 
+              <li> 
                   {{.Pre}}<a class="padding" href="{{.URL | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
               </li>
           {{end}}


### PR DESCRIPTION
Removing class="" because it does not add a whole lot
Removing role="" because it is invalid HTML (cannot be empty) and generates HTML-errors in validators.