### PR TITLE
fix clickable nodes style in mermaid

### DIFF
--- a/static/mermaid/mermaid.css
+++ b/static/mermaid/mermaid.css
@@ -258,6 +258,9 @@ text.actor {
   font-family: 'trebuchet ms', verdana, arial;
   font-size: 14px;
 }
+.node.clickable {
+  cursor: pointer;
+}
 div.mermaidTooltip {
   position: absolute;
   text-align: center;
@@ -271,3 +274,4 @@ div.mermaidTooltip {
   pointer-events: none;
   z-index: 100;
 }
+

--- a/static/mermaid/mermaid.dark.css
+++ b/static/mermaid/mermaid.dark.css
@@ -260,6 +260,9 @@ text.actor {
   font-family: 'trebuchet ms', verdana, arial;
   font-size: 14px;
 }
+.node.clickable {
+  cursor: pointer;
+}
 div.mermaidTooltip {
   position: absolute;
   text-align: center;

--- a/static/mermaid/mermaid.forest.css
+++ b/static/mermaid/mermaid.forest.css
@@ -338,6 +338,9 @@ svg .classLabel .label {
   font-family: 'trebuchet ms', verdana, arial;
   font-size: 14px;
 }
+.node.clickable {
+  cursor: pointer;
+}
 div.mermaidTooltip {
   position: absolute;
   text-align: center;


### PR DESCRIPTION
Hi @matcornic,

Thanks again for this awesome theme! 

As per the referenced https://github.com/matcornic/hugo-theme-learn/issues/168, we can create clickable nodes in mermaid as per the demo site, but the cursor is not being styled correctly. This sorts that out.

 - add CSS ruleset for clickable nodes
 - replace JS with latest minified from mermaidjs.github.io