### PR TITLE
RETRY - Params to turn off next/previous page - and breadcrumb

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,8 +13,8 @@ defaultContentLanguageInSubdir= true
   description = "Documentation for Hugo Learn Theme"
   author = "Mathieu Cornic"
   showVisitedLinks = true
-  disableBreadcrumb = true
-  disableNextPrev = true
+  disableBreadcrumb = false
+  disableNextPrev = false
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]

--- a/exampleSite/content/basics/configuration/_index.en.md
+++ b/exampleSite/content/basics/configuration/_index.en.md
@@ -33,6 +33,10 @@ Note that some of these parameters are explained in details in other sections of
   disableShortcutsTitle = false
   # When using mulitlingual website, disable the switch language button.
   disableLanguageSwitchingButton = false
+  # Hide breadcrumbs in the header and only show the current page title
+  disableBreadcrumb = true
+  # Hide Next and Previous page buttons normally displayed full height beside content
+  disableNextPrev = true
   # Order sections in menu by "weight" or "title". Default to "weight"
   ordersectionsby = "weight"
   # Change default color scheme with a variant one. Can be "red", "blue", "green".

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -40,12 +40,15 @@
         {{ end }}
 
 
-        {{with ($.Scratch.Get "prevPage")}}
-            <a class="nav nav-prev" href="{{.URL}}" title="{{.Title}}"> <i class="fas fa-chevron-left"></i></a>
-        {{end}}
-        {{with ($.Scratch.Get "nextPage")}}
-            <a class="nav nav-next" href="{{.URL}}" title="{{.Title}}" style="margin-right: 0px;"><i class="fas fa-chevron-right"></i></a>
-        {{end}}
+	 {{$showPrevNext := (and (not .Params.disableNextPrev) (not .Site.Params.disableNextPrev))}}
+	 {{if $showPrevNext}}
+		{{with ($.Scratch.Get "prevPage")}}
+			<a class="nav nav-prev" href="{{.URL}}" title="{{.Title}}"> <i class="fa fa-chevron-left"></i></a>
+		{{end}}
+		{{with ($.Scratch.Get "nextPage")}}
+			<a class="nav nav-next" href="{{.URL}}" title="{{.Title}}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>
+		{{end}}
+	{{end}}
     </div>
 
     </section>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -66,7 +66,12 @@
                   <span id="toc-menu"><i class="fas fa-list-alt"></i></span>
                   {{ end }}
                   <span class="links">
-                    {{ template "breadcrumb" dict "page" . "value" .Title }}   
+                 {{$showBreadcrumb := (and (not .Params.disableBreadcrumb) (not .Site.Params.disableBreadcrumb))}}
+                 {{if $showBreadcrumb}}
+                    {{ template "breadcrumb" dict "page" . "value" .Title }}
+                 {{ else }}
+                   {{ .Title }} 
+                 {{ end }}
                   </span>
                 </div>
                 {{ if $toc }}


### PR DESCRIPTION
Continues from #137. I accidentally broke that one.

> Can we merge this in as a sitewide setting and add per-page override to the backlog? I've tried implementing this but can't solve without having both a disableNextPrev and a enableNextPrev.
