### PR TITLE
Fix depth > 1 in children shortcode

### DIFF
--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -67,11 +67,10 @@
 {{if eq $.style "li"}}
 <ul>
 {{end}}
-	{{ $.Page.Scratch.Set "pages" .Pages }}
+	{{ $pages := .Pages }}
     {{ if .Sections}}
-	    {{ $.Page.Scratch.Set "pages" (.Pages | union .Sections) }}
+	    {{ $pages = (.Pages | union .Sections) }}
     {{end}}
-    {{ $pages := ($.Page.Scratch.Get "pages") }}
 
 	{{if eq $.sortTerm "Weight"}}
 		{{template "childs" dict "menu" $pages.ByWeight  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}


### PR DESCRIPTION
The shortcode was not working beyond the first level of the hierarchy of
children. Anything deeper did not give any results.

The fact that this doesn't currently work is clear on the demo site: https://learn.netlify.com/en/shortcodes/children.

Compare this with this demo site with the fix applied: https://robhoes.github.io/hugo-theme-learn/en/shortcodes/children.

Note: this uses the "variable overwrite" feature from Hugo 0.48, so only take this change if you are happy to make that release a requirement.