### PR TITLE
RFC: Menu: only expand active hierarchy

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -97,18 +97,25 @@
  {{with .sect}}
   {{if .IsSection}}
     {{safeHTML .Params.head}}
+    {{ $isParent := or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
+    {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
     <li data-nav-id="{{.URL}}" title="{{.Title}}" class="dd-item 
-        {{if .IsAncestor $currentNode }}parent{{end}}
+        {{if $isParent }}parent{{end}}
         {{if eq .UniqueID $currentNode.UniqueID}}active{{end}}
-        {{if .Params.alwaysopen}}parent{{end}}
         ">
       <a href="{{.RelPermalink}}">
           {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
+          {{ if and (ne $numberOfPages 0) (ne .Parent .Site.Home) }}
+            {{if $isParent }}
+              <i class="fas fa-caret-down"></i>
+            {{ else }}
+              <i class="fas fa-caret-right"></i>
+            {{ end }}
+          {{ end }}
           {{ if $showvisitedlinks}}
             <i class="fas read-icon"></i>
           {{ end }}
       </a>
-      {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
       {{ if ne $numberOfPages 0 }}
         <ul>
           {{ $currentNode.Scratch.Set "pages" .Pages }}

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -257,7 +257,7 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 #sidebar ul.topics ul ul {
     padding-bottom: 0;
 }
-#sidebar ul.topics li.parent ul, #sidebar ul.topics > li.active ul {
+#sidebar ul.topics li.parent > ul {
     display: block;
 }
 #sidebar ul.topics > li > a {


### PR DESCRIPTION
Before this change, the entire menu tree below the selected top-level heading
was expanded.

This change adds some triangles on menu items at level 2 and below to indicate
which ones can be or are expanded. I didn't put them on the top level, because
I felt that it looked too cluttered and didn't add much value.

Fixes #88

Here is an example of what this looks like: https://robhoes.github.io/hugo-theme-learn/en/shortcodes/children.

Would it be desirable to add a configuration option for this, perhaps just for the new marks in the menu?