### PR TITLE
Use menuTitle, if defined, in breadcrumbs.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -68,7 +68,8 @@
                   <span class="links">
                  {{$showBreadcrumb := (and (not .Params.disableBreadcrumb) (not .Site.Params.disableBreadcrumb))}}
                  {{if $showBreadcrumb}}
-                    {{ template "breadcrumb" dict "page" . "value" .Title }}
+                    {{$title := (or .Params.menuTitle .Title)}}
+                    {{ template "breadcrumb" dict "page" . "value" $title }}
                  {{ else }}
                    {{ .Title }} 
                  {{ end }}
@@ -92,7 +93,8 @@
         {{define "breadcrumb"}}
           {{$parent := .page.Parent }}
           {{ if $parent }}
-            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.URL $parent.Title .value) }}
+            {{ $title := (or $parent.Params.menuTitle .Title "")}}
+            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.URL $title .value) }}
             {{ template "breadcrumb" dict "page" $parent "value" $value }} 
           {{else}}
             {{.value|safeHTML}}


### PR DESCRIPTION
Hi -- Developing my first site using the Learn template (Thank you very much!).

I noticed that setting a "menuTitle" in the front matter changes the TOC in the sidebar but does not change the breadcrumbs.  I really think the breadcrumbs should be consistent with the TOC.

This patch fixes the issue for me.  I'm new to Hugo so I have no idea if something should be done to manage backwards compatibility or if it breaks other things or...  Feedback welcome.