### PR TITLE
Use correct input type for search

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,6 +1,6 @@
 <div class="searchbox">
     <label for="search-by"><i class="fas fa-search"></i></label>
-    <input data-search-input id="search-by" type="text" placeholder="{{T "Search-placeholder"}}">
+    <input data-search-input id="search-by" type="search" placeholder="{{T "Search-placeholder"}}">
     <span data-search-clear=""><i class="fas fa-close"></i></span>
 </div>
 {{ $assetBusting := not .Site.Params.disableAssetsBusting }}


### PR DESCRIPTION
This doesn't change functionality but could aid with accessibility and is more semantically correct.