### PR TITLE
prevents left and right keydown in input fields

### DIFF
--- a/static/js/learn.js
+++ b/static/js/learn.js
@@ -223,6 +223,13 @@ jQuery(document).ready(function() {
         });
     });
 
+    jQuery('input').keydown(function (e) {
+         //  left and right arrow keys
+         if (e.which == '37' || e.which == '39') {
+             e.stopPropagation();
+         }
+     });
+    
     jQuery(document).keydown(function(e) {
       // prev links - left arrow key
       if(e.which == '37') {


### PR DESCRIPTION
If input field is in focus, keydown event to trigger navigation change should
not fire. User should expect cursor to stay in input field when using arrow keys.

Fixes #216 