### PR TITLE
Fix translation when using a custom baseURL

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -57,9 +57,9 @@
                   {{ if eq $translation.Lang .Lang }}
                     {{ $selected := false }}
                     {{ if eq $pageLang .Lang}}
-                      <option id="{{ $translation.Language }}" value="{{ $translation.URL }}" selected>{{ .LanguageName }}</option>
+                      <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}" selected>{{ .LanguageName }}</option>
                     {{ else }}
-                      <option id="{{ $translation.Language }}" value="{{ $translation.URL }}">{{ .LanguageName }}</option>
+                      <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}">{{ .LanguageName }}</option>
                     {{ end }}
                   {{ end }}
               {{ end }}


### PR DESCRIPTION
When the ``baseURL`` is not ``/`` using ``$translation.URL`` is ignoring the ``baseURL``.
In order to sort this behavior, ``$translation.Permalink`` is working just fine.