### PR TITLE
Preventing left/right arrow key navigation in textareas

### DIFF
--- a/static/js/learn.js
+++ b/static/js/learn.js
@@ -223,7 +223,7 @@ jQuery(document).ready(function() {
         });
     });
 
-    jQuery('input').keydown(function (e) {
+    jQuery('input, textarea').keydown(function (e) {
          //  left and right arrow keys
          if (e.which == '37' || e.which == '39') {
              e.stopPropagation();


### PR DESCRIPTION
Preventing left/right arrow key navigation in textareas. This takes advantage of the existing code added by #219.

Fixes #240.