### PR TITLE
fix language switcher with baseurl

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -50,6 +50,7 @@
           <div class="select-style">
             <select id="select-language" onchange="location = this.value;">
           {{ $siteLanguages := .Site.Languages}}
+          {{ $baseUrl := .Site.BaseURL}}
           {{ $pageLang := .Page.Lang}}
           {{ range .Page.AllTranslations }}
               {{ $translation := .}}
@@ -57,9 +58,9 @@
                   {{ if eq $translation.Lang .Lang }}
                     {{ $selected := false }}
                     {{ if eq $pageLang .Lang}}
-                      <option id="{{ $translation.Language }}" value="{{ $translation.URL }}" selected>{{ .LanguageName }}</option>
+                      <option id="{{ $translation.Language }}" value="{{ $baseUrl }}{{ $translation.URL }}" selected>{{ .LanguageName }}</option>
                     {{ else }}
-                      <option id="{{ $translation.Language }}" value="{{ $translation.URL }}">{{ .LanguageName }}</option>
+                      <option id="{{ $translation.Language }}" value="{{ $baseUrl }}{{ $translation.URL }}">{{ .LanguageName }}</option>
                     {{ end }}
                   {{ end }}
               {{ end }}
@@ -147,4 +148,3 @@
   {{end}}
  {{ end }}
 {{ end }}
-


### PR DESCRIPTION
This fixes a similar problem to #156. The language switcher does not consider the `baseURL` when set. This causes the language switcher to not work properly, when the built site is used in a sub folder of the domain.

/cc @sheeep