### PR TITLE
Fix issue where "children" shortcode only shows top level.

### DIFF
--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -4,13 +4,20 @@
 {{ $withDescription :=  .Get "description" | default false }}
 {{ $sortTerm :=  .Get "sort" | default "Weight" }}
 
-
 <ul class="children children-{{$style}}">
 	{{ .Scratch.Set "pages" .Page.Pages }}
-    {{ if .Page.Sections}}
-	    {{ .Scratch.Set "pages" (.Page.Pages | union .Page.Sections) }}
-    {{end}}
-    {{ $pages := (.Scratch.Get "pages") }}
+
+	{{if .Page.IsHome}}
+		<!-- Add pages that are in root dir -->
+		{{ $rootPage := where .Page.Pages "Dir" "" }}
+		{{ .Scratch.Set "pages" (.Page.Sections | union $rootPage)}}
+	{{else}}
+		{{ if .Page.Sections}}
+			{{ .Scratch.Set "pages" (.Page.Pages | union .Page.Sections) }}
+		{{end}}
+	{{end}}
+	
+	{{ $pages := (.Scratch.Get "pages") }}
 
 	{{if eq $sortTerm "Weight"}}
 		{{template "childs" dict "menu" $pages.ByWeight "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
@@ -33,64 +40,61 @@
 	{{ range .menu }}
 		{{ if and .Params.hidden (not $.showhidden) }} 
 		{{else}}
-  
+			{{if not .IsHome}}
+				{{if hasPrefix $.style "h"}}
+					{{$num := sub ( int (trim $.style "h") ) 1 }}
+					{{$numn := add $num $.count }}
 
-{{if hasPrefix $.style "h"}}
-	{{$num := sub ( int (trim $.style "h") ) 1 }}
-	{{$numn := add $num $.count }}
+					{{(printf "<h%d>" $numn)|safeHTML}}
+					<a href="{{.URL}}" >{{ .Title }}</a>
+					{{(printf "</h%d>" $numn)|safeHTML}}
 
-{{(printf "<h%d>" $numn)|safeHTML}}
-<a href="{{.URL}}" >{{ .Title }}</a>
-{{(printf "</h%d>" $numn)|safeHTML}}
-
-{{else}}
-{{(printf "<%s>" $.style)|safeHTML}}
-<a href="{{.URL}}" >{{ .Title }}</a>
-{{(printf "</%s>" $.style)|safeHTML}}
-{{end}}
-
-
-
-
-
-			{{if $.description}}
-				{{if .Description}}
-<p>{{.Description}}</p>
 				{{else}}
-<p>{{.Summary}}</p>
+					{{(printf "<%s>" $.style)|safeHTML}}
+					<a href="{{.URL}}" >{{ .Title }}</a>
+					{{(printf "</%s>" $.style)|safeHTML}}
+				{{end}}
+
+				{{if $.description}}
+					{{if .Description}}
+						<p>{{.Description}}</p>
+					{{else}}
+						<p>{{.Summary}}</p>
+					{{end}}
 				{{end}}
 			{{end}}
-		
-
-		
 			{{ if lt $.count $.depth}}
-{{if eq $.style "li"}}
-<ul>
-{{end}}
-	{{ .Scratch.Set "pages" .Pages }}
-    {{ if .Sections}}
-	    {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
-    {{end}}
-    {{ $pages := (.Scratch.Get "pages") }}
 
-	{{if eq $.sortTerm "Weight"}}
-		{{template "childs" dict "menu" $pages.ByWeight  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else if eq $.sortTerm "Name"}}
-		{{template "childs" dict "menu" $pages.ByTitle  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else if eq $.sortTerm "PublishDate"}}
-		{{template "childs" dict "menu" $pages.ByPublishDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else if eq $.sortTerm "Date"}}
-		{{template "childs" dict "menu" $pages.ByDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else if eq $.sortTerm "Length"}}
-		{{template "childs" dict "menu" $pages.ByLength  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else}}
-		{{template "childs" dict "menu" $pages  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{end}}
-{{if eq $.style "li"}}
-</ul>
-{{end}}
+				{{if eq $.style "li"}}
+					<ul>
+				{{end}}
+
+				{{ if .Sections}}
+					{{ .Scratch.Set "pages" (.Pages | union .Sections) }}
+				{{else}}
+					{{ .Scratch.Set "pages" .Pages }}
+				{{end}}
+				
+				{{ $pages := (.Scratch.Get "pages") }}
+
+				{{if eq $.sortTerm "Weight"}}
+					{{template "childs" dict "menu" $pages.ByWeight  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else if eq $.sortTerm "Name"}}
+					{{template "childs" dict "menu" $pages.ByTitle  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else if eq $.sortTerm "PublishDate"}}
+					{{template "childs" dict "menu" $pages.ByPublishDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else if eq $.sortTerm "Date"}}
+					{{template "childs" dict "menu" $pages.ByDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else if eq $.sortTerm "Length"}}
+					{{template "childs" dict "menu" $pages.ByLength  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{else}}
+					{{template "childs" dict "menu" $pages  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+				{{end}}
+
+				{{if eq $.style "li"}}
+					</ul>
+				{{end}}
 			{{end}}
-
 		{{end}}
 	{{end}}
 {{end}}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -45,28 +45,28 @@
 					{{$num := sub ( int (trim $.style "h") ) 1 }}
 					{{$numn := add $num $.count }}
 
-					{{(printf "<h%d>" $numn)|safeHTML}}
-					<a href="{{.URL}}" >{{ .Title }}</a>
-					{{(printf "</h%d>" $numn)|safeHTML}}
+{{(printf "<h%d>" $numn)|safeHTML}}
+<a href="{{.URL}}" >{{ .Title }}</a>
+{{(printf "</h%d>" $numn)|safeHTML}}
 
 				{{else}}
-					{{(printf "<%s>" $.style)|safeHTML}}
-					<a href="{{.URL}}" >{{ .Title }}</a>
-					{{(printf "</%s>" $.style)|safeHTML}}
+{{(printf "<%s>" $.style)|safeHTML}}
+<a href="{{.URL}}" >{{ .Title }}</a>
+{{(printf "</%s>" $.style)|safeHTML}}
 				{{end}}
 
 				{{if $.description}}
 					{{if .Description}}
-						<p>{{.Description}}</p>
+<p>{{.Description}}</p>
 					{{else}}
-						<p>{{.Summary}}</p>
+<p>{{.Summary}}</p>
 					{{end}}
 				{{end}}
 			{{end}}
 			{{ if lt $.count $.depth}}
 
 				{{if eq $.style "li"}}
-					<ul>
+<ul>
 				{{end}}
 
 				{{ if .Sections}}
@@ -92,7 +92,7 @@
 				{{end}}
 
 				{{if eq $.style "li"}}
-					</ul>
+</ul>
 				{{end}}
 			{{end}}
 		{{end}}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -67,11 +67,11 @@
 {{if eq $.style "li"}}
 <ul>
 {{end}}
-	{{ $.Page.Scratch.Set "pages" .Pages }}
+	{{ .Scratch.Set "pages" .Pages }}
     {{ if .Sections}}
-	    {{ $.Page.Scratch.Set "pages" (.Pages | union .Sections) }}
+	    {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
     {{end}}
-    {{ $pages := ($.Page.Scratch.Get "pages") }}
+    {{ $pages := (.Scratch.Get "pages") }}
 
 	{{if eq $.sortTerm "Weight"}}
 		{{template "childs" dict "menu" $pages.ByWeight  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}


### PR DESCRIPTION
As Explained in [PR 194](https://github.com/matcornic/hugo-theme-learn/pull/194), there is a bug in the children shortcode where it only returns the top level.

This pull request is to fix this issue.

Unlike PR 194, this fix works on 0.26