### PR TITLE
Add a special tag to skip file from indexing

### DIFF
--- a/exampleSite/content/basics/configuration/_index.en.md
+++ b/exampleSite/content/basics/configuration/_index.en.md
@@ -52,6 +52,17 @@ If not already present, add the follow lines in the same `config.toml` file.
 home = [ "HTML", "RSS", "JSON"]
 ```
 
+Sometimes, a huge search page can make the indexing and search very slow. To prevent a page from being indexed, give it the special tag 'skipIndexing':
+
+```toml
+---
+title: "My very big page"
+date: 2019-03-13T18:28:08-07:00
+draft: false
+tags: ['skipIndexing']
+---
+```
+
 Learn theme uses the last improvement available in hugo version 20+ to generate a json index file ready to be consumed by lunr.js javascript search engine.
 
 > Hugo generate lunrjs index.json at the root of public folder. 

--- a/exampleSite/content/basics/configuration/_index.fr.md
+++ b/exampleSite/content/basics/configuration/_index.fr.md
@@ -48,6 +48,18 @@ Si ce n'est pas déjà présent, ajoutez les lignes suivantes dans le fichier `c
 home = [ "HTML", "RSS", "JSON"]
 ```
 
+Parfois, des grosses page peuvent rentre l'indexement et la recherche lentes. Pour éviter cela, il suffit d'ajouter aux pages le tag 'skipIndexing':
+
+```toml
+---
+title: "Ma tres grosse page"
+date: 2019-03-13T18:28:08-07:00
+draft: false
+tags: ['skipIndexing']
+---
+```
+
+
 Le thème *Learn* utilise les dernières amélioraions d'Hugo pour générer un fichier d'index JSON, prêt à être consommé par le moteur de recherche lunr.js.
 
 > Hugo génère lunrjs index.json à la racine du dossier `public`. 

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -12,5 +12,6 @@
     {{ else }}
         var baseurl = "{{.Site.BaseURL}}";
     {{ end }}
+    var fileSearchBlacklist = "{{.Site.Params.fileSearchBlacklist}}";
 </script>
 <script type="text/javascript" src="{{"js/search.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -13,7 +13,7 @@ function initLunr() {
     // First retrieve the index file
     $.getJSON(baseurl +"index.json")
         .done(function(index) {
-            pagesIndex =   index;
+            pagesIndex = index;
             // Set up lunrjs by declaring the fields we use
             // Also provide their boost level for the ranking
             lunrIndex = new lunr.Index
@@ -30,7 +30,9 @@ function initLunr() {
 
             // Feed lunr with each file and let lunr actually index them
             pagesIndex.forEach(function(page) {
-                lunrIndex.add(page);
+                if (page.tags.indexOf('skipIndexing') == -1) {                
+                  lunrIndex.add(page);
+                }
             });
             lunrIndex.pipeline.remove(lunrIndex.stemmer)
         })


### PR DESCRIPTION
Sometimes, there are a few huge pages that hangs the search.
By simply tagging them with the 'skipIndexing', they will be omitted and the search will
stay fast.

e.g.

---
title: "My very big page"
date: 2019-03-13T18:28:08-07:00
draft: false
tags: ['skipIndexing']
---

Added to the documentation too.