### PR TITLE
Make shortcodes & example site compatible with Hugo v0.55

### DIFF
--- a/exampleSite/content/basics/installation/_index.en.md
+++ b/exampleSite/content/basics/installation/_index.en.md
@@ -48,7 +48,7 @@ Discover what this Hugo theme is all about and the core concepts behind it.
 
 renders as 
 
-![A Chapter](/basics/installation/images/chapter.png?classes=shadow&width=60pc)
+![A Chapter](/en/basics/installation/images/chapter.png?classes=shadow&width=60pc)
 
 **Hugo-theme-learn** provides archetypes to create skeletons for your website. Begin by creating your first chapter page with the following command
 

--- a/exampleSite/content/basics/installation/_index.fr.md
+++ b/exampleSite/content/basics/installation/_index.fr.md
@@ -48,7 +48,7 @@ Découvrez comment utiliser ce thème Hugo et apprenez en les concepts
 
 s'affiche comme
 
-![Un chapitre](/basics/installation/images/chapter.png?classes=shadow&width=60pc)
+![Un chapitre](/en/basics/installation/images/chapter.png?classes=shadow&width=60pc)
 
 **Hugo-theme-learn** fournit des archétypes pour créer des squelettes pour votre site. Commencez par créer votre premier chapitre avec la commande suivante:
 

--- a/exampleSite/content/basics/requirements/_index.en.md
+++ b/exampleSite/content/basics/requirements/_index.en.md
@@ -8,4 +8,4 @@ Thanks to the simplicity of Hugo, this page is as empty as this theme needs requ
 
 Just download latest version of [Hugo binary (> 0.25)](https://gohugo.io/getting-started/installing/) for your OS (Windows, Linux, Mac) : it's that simple.
 
-![Magic](/basics/requirements/images/magic.gif?classes=shadow)
+![Magic](/en/basics/requirements/images/magic.gif?classes=shadow)

--- a/exampleSite/content/basics/requirements/_index.fr.md
+++ b/exampleSite/content/basics/requirements/_index.fr.md
@@ -8,4 +8,4 @@ Grâce à la simplicité d'Hugo, cette page est vide car il n'y a quasi pas de p
 
 Téléchargez la dernière version du [binaire Hugo (> 0.25)](https://gohugo.io/getting-started/installing/) pour votre Système d'exploitation (Windows, Linux, Mac) : et c'est tout !
 
-![Magic](/basics/requirements/images/magic.gif?classes=shadow)
+![Magic](/en/basics/requirements/images/magic.gif?classes=shadow)

--- a/exampleSite/content/basics/style-customization/_index.en.md
+++ b/exampleSite/content/basics/style-customization/_index.en.md
@@ -53,7 +53,7 @@ If you need to change this default behavior, create a new file in `layouts/parti
   themeVariant = "red"
 ```
 
-![Red variant](/basics/style-customization/images/red-variant.png?width=60pc)
+![Red variant](/en/basics/style-customization/images/red-variant.png?width=60pc)
 
 ### Blue variant
 
@@ -63,7 +63,7 @@ If you need to change this default behavior, create a new file in `layouts/parti
   themeVariant = "blue"
 ```
 
-![Blue variant](/basics/style-customization/images/blue-variant.png?width=60pc)
+![Blue variant](/en/basics/style-customization/images/blue-variant.png?width=60pc)
 
 ### Green variant
 
@@ -73,7 +73,7 @@ If you need to change this default behavior, create a new file in `layouts/parti
   themeVariant = "green"
 ```
 
-![Green variant](/basics/style-customization/images/green-variant.png?width=60pc)
+![Green variant](/en/basics/style-customization/images/green-variant.png?width=60pc)
 
 ### 'Yours‘ variant
 

--- a/exampleSite/content/basics/style-customization/_index.fr.md
+++ b/exampleSite/content/basics/style-customization/_index.fr.md
@@ -53,7 +53,7 @@ Si vous avez besoin de changer ce comportement par défaut, créer un nouveau fi
   themeVariant = "red"
 ```
 
-![Variante rouge](/basics/style-customization/images/red-variant.png?width=60pc)
+![Variante rouge](/en/basics/style-customization/images/red-variant.png?width=60pc)
 
 ### Variante bleue
 
@@ -63,7 +63,7 @@ Si vous avez besoin de changer ce comportement par défaut, créer un nouveau fi
   themeVariant = "blue"
 ```
 
-![Variante bleue](/basics/style-customization/images/blue-variant.png?width=60pc)
+![Variante bleue](/en/basics/style-customization/images/blue-variant.png?width=60pc)
 
 ### Variante verte
 
@@ -73,7 +73,7 @@ Si vous avez besoin de changer ce comportement par défaut, créer un nouveau fi
   themeVariant = "green"
 ```
 
-![Variante verte](/basics/style-customization/images/green-variant.png?width=60pc)
+![Variante verte](/en/basics/style-customization/images/green-variant.png?width=60pc)
 
 ### Votre variante
 

--- a/exampleSite/content/cont/i18n/_index.en.md
+++ b/exampleSite/content/cont/i18n/_index.en.md
@@ -12,7 +12,7 @@ It provides:
 - Automatic menu generation from multilingual content
 - In-browser language switching
 
-![I18n menu](/cont/i18n/images/i18n-menu.gif)
+![I18n menu](/en/cont/i18n/images/i18n-menu.gif)
 
 ## Basic configuration
 
@@ -75,4 +75,4 @@ Just set `disableLanguageSwitchingButton=true` in your `config.toml`
   disableLanguageSwitchingButton = true
 ```
 
-![I18n menu](/cont/i18n/images/i18n-menu.gif)
+![I18n menu](/en/cont/i18n/images/i18n-menu.gif)

--- a/exampleSite/content/cont/i18n/_index.fr.md
+++ b/exampleSite/content/cont/i18n/_index.fr.md
@@ -12,7 +12,7 @@ Il fournit :
 - Génération automatique du menu avec le contenu multi-langue
 - Modification de la langue dans le navigateur
 
-![I18n menu](/cont/i18n/images/i18n-menu.gif)
+![I18n menu](/en/cont/i18n/images/i18n-menu.gif)
 
 ## Configuration simple
 
@@ -75,4 +75,4 @@ Pour ce faire, ajouter le paramètre `disableLanguageSwitchingButton=true` dans 
   disableLanguageSwitchingButton = true
 ```
 
-![I18n menu](/cont/i18n/images/i18n-menu.gif)
+![I18n menu](/en/cont/i18n/images/i18n-menu.gif)

--- a/exampleSite/content/cont/pages/_index.en.md
+++ b/exampleSite/content/cont/pages/_index.en.md
@@ -45,7 +45,7 @@ Organize your site like [any other Hugo project](https://gohugo.io/content/organ
 A **Chapter** displays a page meant to be used as introduction for a set of child pages. Commonly, it contains a simple title and a catch line to define content that can be found under it.
 You can define any HTML as prefix for the menu. In the example below, it's just a number but that could be an [icon](https://fortawesome.github.io/Font-Awesome/).
 
-![Chapter page](/cont/pages/images/pages-chapter.png?width=50pc)
+![Chapter page](/en/cont/pages/images/pages-chapter.png?width=50pc)
 
 ```markdown
 +++
@@ -66,7 +66,7 @@ To tell **Hugo-theme-learn** to consider a page as a chapter, set `chapter=true`
 
 A **Default** page is any other content page.
 
-![Default page](/cont/pages/images/pages-default.png?width=50pc)
+![Default page](/en/cont/pages/images/pages-default.png?width=50pc)
 
 ```toml
 +++
@@ -126,7 +126,7 @@ pre = "<i class='fab fa-github'></i> "
 +++
 ```
 
-![Title with icon](/cont/pages/images/frontmatter-icon.png)
+![Title with icon](/en/cont/pages/images/frontmatter-icon.png)
 
 ### Ordering sibling menu/page entries
 

--- a/exampleSite/content/cont/pages/_index.fr.md
+++ b/exampleSite/content/cont/pages/_index.fr.md
@@ -45,7 +45,7 @@ Le fichier `_index.md` est obligatoire dans chaque dossier, c'est en quelques ro
 Un **Chapitre** affiche une page vouée à être une introduction pour un ensemble de pages filles. Habituellement, il va seulement contenir un titre et un résumé de la section.
 Vous pouvez définir n'importe quel contenu HTML comme préfixe de l'entrée du menu. Dans l'exemple ci-dessous, c'est juste un nombre mais vous pourriez utiliser une [icône](https://fortawesome.github.io/Font-Awesome/).
 
-![Page Chapitre](/cont/pages/images/pages-chapter.png?width=50pc)
+![Page Chapitre](/en/cont/pages/images/pages-chapter.png?width=50pc)
 
 ```markdown
 +++
@@ -66,7 +66,7 @@ Pour dire à **Hugo-theme-learn** de considérer la page comme un chapitre, conf
 
 Une page **Défaut** est n'importe quelle autre page.
 
-![Page défaut](/cont/pages/images/pages-default.png?width=50pc)
+![Page défaut](/en/cont/pages/images/pages-default.png?width=50pc)
 
     +++
     title = "Installation"
@@ -122,7 +122,7 @@ pre = "<i class='fab fa-github'></i> "
 +++
 ```
 
-![Titre avec icône](/cont/pages/images/frontmatter-icon.png)
+![Titre avec icône](/en/cont/pages/images/frontmatter-icon.png)
 
 ### Ordonner les entrées dans le menu
 

--- a/layouts/shortcodes/attachments.html
+++ b/layouts/shortcodes/attachments.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 <section class="attachments {{ with .Get "style"}}{{.}}{{ end }}">
 	<label>
 		<i class="fas fa-paperclip" aria-hidden="true"></i>

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 <a {{ with .Get "href"}} href="{{.}}" target="_blank" {{ end }} class="btn btn-default">
   {{ $icon := .Get "icon" }}
   {{ $iconposition := .Get "icon-position" }}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 {{ $showhidden := .Get "showhidden"}}
 {{ $style :=  .Get "style" | default "li" }}
 {{ $depth :=  .Get "depth" | default 1 }}
@@ -16,7 +17,7 @@
 			{{ .Scratch.Set "pages" (.Page.Pages | union .Page.Sections) }}
 		{{end}}
 	{{end}}
-	
+
 	{{ $pages := (.Scratch.Get "pages") }}
 
 	{{if eq $sortTerm "Weight"}}
@@ -38,7 +39,7 @@
 
 {{ define "childs" }}
 	{{ range .menu }}
-		{{ if and .Params.hidden (not $.showhidden) }} 
+		{{ if and .Params.hidden (not $.showhidden) }}
 		{{else}}
 			{{if not .IsHome}}
 				{{if hasPrefix $.style "h"}}
@@ -74,7 +75,7 @@
 				{{else}}
 					{{ .Scratch.Set "pages" .Pages }}
 				{{end}}
-				
+
 				{{ $pages := (.Scratch.Get "pages") }}
 
 				{{if eq $.sortTerm "Weight"}}

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
         <i style="font-size:x-small;" class="fas fa-chevron-right"></i>

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,1 +1,2 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 <div class="mermaid" align="{{ if .Get "align" }}{{ .Get "align" }}{{ else }}center{{ end }}">{{ safeHTML .Inner }}</div>

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,1 +1,2 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 <div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>{{ .Inner }}</div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   HUGO_THEME = "repo"
   HUGO_THEMESDIR = "/opt/build"
-  HUGO_VERSION = "0.50"
+  HUGO_VERSION = "0.55"
 
 [context.production.environment]
   HUGO_BASEURL = "https://learn.netlify.com/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   HUGO_THEME = "repo"
   HUGO_THEMESDIR = "/opt/build"
-  HUGO_VERSION = "0.55"
+  HUGO_VERSION = "0.55.5"
 
 [context.production.environment]
   HUGO_BASEURL = "https://learn.netlify.com/"


### PR DESCRIPTION
Fixes #272 
Fixes #273 
Fixes #282

This PR simply marks all shortcodes to use hugo's old rendering mechanism for shortcodes.