### PR TITLE
remove unneeded  type="text/css"

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
 
     <script src="{{"js/jquery-3.3.1.min.js"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
 
-    <style type="text/css">
+    <style>
       :root #header + #content > #left > #rlblock_left{
           display:none !important;
       }


### PR DESCRIPTION
It's not needed on HTML5.
REF: https://google.github.io/styleguide/htmlcssguide.html#type_Attributes