### PR TITLE
Fixing dangling <ul> when no pages or subsections are shown within the submenu

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -110,29 +110,38 @@
       </a>
       {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
       {{ if ne $numberOfPages 0 }}
-        <ul>
           {{ $currentNode.Scratch.Set "pages" .Pages }}
           {{ if .Sections}}
             {{ $currentNode.Scratch.Set "pages" (.Pages | union .Sections) }}
           {{end}}
           {{ $pages := ($currentNode.Scratch.Get "pages") }}
-          
-        {{if eq .Site.Params.ordersectionsby "title"}}  
-          {{ range $pages.ByTitle }}
-            {{ if and .Params.hidden (not $.showhidden) }} 
+
+          {{ $currentNode.Scratch.Set "allHidden" true}}
+            {{ range $pages }}
+              {{ if not .Params.hidden }}
+                {{ $currentNode.Scratch.Set "allHidden" false }}
+              {{ end }}
+            {{ end }}
+            {{ $allHidden := $currentNode.Scratch.Get "allHidden" }}
+          {{ if not $allHidden }}  
+            <ul>
+            {{if eq .Site.Params.ordersectionsby "title"}}  
+              {{ range $pages.ByTitle }}
+                {{ if and .Params.hidden (not $.showhidden) }} 
+                {{else}}
+                {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+                {{end}}
+              {{ end }}
             {{else}}
-            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+              {{ range $pages.ByWeight }}
+                {{ if and .Params.hidden (not $.showhidden) }} 
+                {{else}}
+                {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+                {{end}}
+              {{ end }}
             {{end}}
-          {{ end }}
-        {{else}}
-          {{ range $pages.ByWeight }}
-            {{ if and .Params.hidden (not $.showhidden) }} 
-            {{else}}
-            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
-            {{end}}
-          {{ end }}
-        {{end}}
-        </ul>
+            </ul>
+          {{end}}
       {{ end }}        
     </li>
   {{else}}


### PR DESCRIPTION
Hi, 

I realized that when you only have hidden pages or subsections in your menu, the html tag <ul> will still be created with nothing inside. This causes a space to be added for submenus, but since they are hidden, nothing else is inside that space. 

Here is an image of what I mean. 

![Screen Shot 2019-06-05 at 11 30 57 AM](https://user-images.githubusercontent.com/1594240/58974349-d5464e00-8787-11e9-868f-6515141dde4b.png)

I have added a variable to check if all the pages or sections are hidden. if so, then it would not try to render a submenu. 

Let me know if this works. 
