### PR TITLE
Fix deprecated .Hugo, .UniqueID and .URL references

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -7,7 +7,7 @@
 {{ if or (eq .Kind "taxonomy") (eq .Kind "taxonomyTerm") }}
 <ul>
 	{{ range .Pages }}
-		<li><a href="{{.URL}}">{{.Title}}</a></li>
+		<li><a href="{{.RelPermalink}}">{{.Title}}</a></li>
 	{{ end }}
 </ul>
 {{end}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,7 @@
         {{ define "menu-nextprev" }}
             {{$currentNode := .currentnode }}
             {{ if ne .menu.Params.hidden true}}
-                {{if hasPrefix $currentNode.URL .menu.URL }}
+                {{if hasPrefix $currentNode.RelPermalink .menu.RelPermalink }}
                     {{ $currentNode.Scratch.Set "NextPageOK" "OK" }}
                     {{ $currentNode.Scratch.Set "prevPage" ($currentNode.Scratch.Get "prevPageTmp") }}
                 {{else}}
@@ -43,10 +43,10 @@
 	 {{$showPrevNext := (and (not .Params.disableNextPrev) (not .Site.Params.disableNextPrev))}}
 	 {{if $showPrevNext}}
 		{{with ($.Scratch.Get "prevPage")}}
-			<a class="nav nav-prev" href="{{.URL}}" title="{{.Title}}"> <i class="fa fa-chevron-left"></i></a>
+			<a class="nav nav-prev" href="{{.RelPermalink}}" title="{{.Title}}"> <i class="fa fa-chevron-left"></i></a>
 		{{end}}
 		{{with ($.Scratch.Get "nextPage")}}
-			<a class="nav nav-next" href="{{.URL}}" title="{{.Title}}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>
+			<a class="nav nav-next" href="{{.RelPermalink}}" title="{{.Title}}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>
 		{{end}}
 	{{end}}
     </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
     {{ partial "meta.html" . }}
     {{ partial "favicon.html" . }}
     <title>{{ .Title }} :: {{ .Site.Title }}</title>
@@ -100,7 +100,7 @@
         {{define "breadcrumb"}}
           {{$parent := .page.Parent }}
           {{ if $parent }}
-            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.URL $parent.Title .value) }}
+            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.RelPermalink $parent.Title .value) }}
             {{ template "breadcrumb" dict "page" $parent "value" $value }} 
           {{else}}
             {{.value|safeHTML}}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -32,7 +32,7 @@
         <ul>
           {{ range sort . "Weight"}}
               <li> 
-                  {{.Pre}}<a class="padding" href="{{.RelPermalink | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
+                  {{.Pre}}<a class="padding" href="{{.URL | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
               </li>
           {{end}}
         </ul>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -32,7 +32,7 @@
         <ul>
           {{ range sort . "Weight"}}
               <li> 
-                  {{.Pre}}<a class="padding" href="{{.URL | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
+                  {{.Pre}}<a class="padding" href="{{.RelPermalink | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
               </li>
           {{end}}
         </ul>
@@ -97,9 +97,9 @@
  {{with .sect}}
   {{if .IsSection}}
     {{safeHTML .Params.head}}
-    <li data-nav-id="{{.URL}}" title="{{.Title}}" class="dd-item 
+    <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item 
         {{if .IsAncestor $currentNode }}parent{{end}}
-        {{if eq .UniqueID $currentNode.UniqueID}}active{{end}}
+        {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}
         {{if .Params.alwaysopen}}parent{{end}}
         ">
       <a href="{{.RelPermalink}}">
@@ -137,7 +137,7 @@
     </li>
   {{else}}
     {{ if not .Params.Hidden }}
-      <li data-nav-id="{{.URL}}" title="{{.Title}}" class="dd-item {{if eq .UniqueID $currentNode.UniqueID}}active{{end}}">
+      <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}">
         <a href="{{ .RelPermalink}}">
         {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
         {{ if $showvisitedlinks}}<i class="fas fa-check read-icon"></i>{{end}}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -47,12 +47,12 @@
 					{{$numn := add $num $.count }}
 
 {{(printf "<h%d>" $numn)|safeHTML}}
-<a href="{{.URL}}" >{{ .Title }}</a>
+<a href="{{.RelPermalink}}" >{{ .Title }}</a>
 {{(printf "</h%d>" $numn)|safeHTML}}
 
 				{{else}}
 {{(printf "<%s>" $.style)|safeHTML}}
-<a href="{{.URL}}" >{{ .Title }}</a>
+<a href="{{.RelPermalink}}" >{{ .Title }}</a>
 {{(printf "</%s>" $.style)|safeHTML}}
 				{{end}}
 

--- a/layouts/shortcodes/ref.html
+++ b/layouts/shortcodes/ref.html
@@ -7,7 +7,7 @@
 	{{- end -}}
 {{- else -}}
 	{{- with .Site.GetPage "section" (.Get 0) }}
-		{{- .URL -}}
+		{{- .RelPermalink -}}
 	{{- else -}}
 		{{- .Get 0 | relref .Page -}}
 	{{- end -}}

--- a/layouts/shortcodes/relref.html
+++ b/layouts/shortcodes/relref.html
@@ -7,7 +7,7 @@
 	{{- end -}}
 {{- else -}}
 	{{- with .Site.GetPage "section" (.Get 0) }}
-		{{- .URL -}}
+		{{- .RelPermalink -}}
 	{{- else -}}
 		{{- .Get 0 | relref .Page -}}
 	{{- end -}}


### PR DESCRIPTION
There is still a warning about using .File on a zero object, but as far as I can tell it doesn't affect page generation.