### PR TITLE
Provide the right extension for tags when using uglyURLs

### DIFF
--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,7 +1,7 @@
 {{ if .Params.tags }}
 <div class="tags">
 {{range .Params.tags}}
-  <a class="tag-link" href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a>
+  <a class="tag-link" href="{{ "/tags/" | relLangURL }}{{ . | urlize }}{{ if $.Site.Params.uglyURLs }}.html{{else}}/{{ end }}">{{ . }}</a>
 {{end}}
 </div>
 {{end}}


### PR DESCRIPTION
This PR fixes an edge case bug when setting the site parameter `uglyURLs` to `true`. This would make all the tag links point to blank pages.

You can find more information about this bug on https://github.com/gohugoio/hugo/issues/1989 .

The fix is shamelessly lifted from https://github.com/olOwOlo/hugo-theme-even/pull/129 . Thank you kind stranger.

I usually don't do whatever this language is. Please clobber me for style.