### PR TITLE
Added flag to turn off image featherlight

### DIFF
--- a/exampleSite/content/cont/markdown.en.md
+++ b/exampleSite/content/cont/markdown.en.md
@@ -663,3 +663,11 @@ Add a HTTP `classes` parameter to the link image to add CSS classes. `shadow`and
 ![stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg?classes=border,shadow)
 ```
 ![stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg?width=40pc&classes=border,shadow)
+
+### Lightbox
+
+Add a HTTP `featherlight` parameter to the link image to disable lightbox. By default lightbox is enabled using the featherlight.js plugin. You can disable this by defining `featherlight` to `false`. 
+
+```markdown
+![Minion](https://octodex.github.com/images/minion.png?featherlight=false)
+```

--- a/static/js/hugo-learn.js
+++ b/static/js/hugo-learn.js
@@ -21,8 +21,13 @@ var images = $("div#body-inner img").not(".inline");
 // Wrap image inside a featherlight (to get a full size view in a popup)
 images.wrap(function(){
   var image =$(this);
-  if (!image.parent("a").length) {
-    return "<a href='" + image[0].src + "' data-featherlight='image'></a>";
+  var o = getUrlParameter(image[0].src);
+  var f = o['featherlight'];
+  // IF featherlight is false, do not use feather light
+  if (f != 'false') {
+    if (!image.parent("a").length) {
+      return "<a href='" + image[0].src + "' data-featherlight='image'></a>";
+    }
   }
 });
 


### PR DESCRIPTION
This PR is to handle #322 together with changes in the documentation. 

If an image has the HTTP parameter featherlight set to false, it will not add the data attributes needed to for the featherlight JS plugin.