### PR TITLE
fix and simplify language menu

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -49,21 +49,13 @@
             <i class="fas fa-language fa-fw"></i>
           <div class="select-style">
             <select id="select-language" onchange="location = this.value;">
-          {{ $siteLanguages := .Site.Languages}}
-          {{ $pageLang := .Page.Lang}}
-          {{ range .Page.AllTranslations }}
-              {{ $translation := .}}
-              {{ range $siteLanguages }}
-                  {{ if eq $translation.Lang .Lang }}
-                    {{ $selected := false }}
-                    {{ if eq $pageLang .Lang}}
-                      <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}" selected>{{ .LanguageName }}</option>
-                    {{ else }}
-                      <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}">{{ .LanguageName }}</option>
-                    {{ end }}
-                  {{ end }}
+              {{ range .AllTranslations }}
+                {{ if eq .Page.Lang .Lang }}
+                  <option id="{{ .Language }}" value="{{ .Permalink }}" selected>{{ .Language.LanguageName }}</option>
+                {{ else }}
+                  <option id="{{ .Language }}" value="{{ .Permalink }}">{{ .Language.LanguageName }}</option>
+                {{ end }}
               {{ end }}
-          {{ end }}
         </select>
         <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
           width="255px" height="255px" viewBox="0 0 255 255" style="enable-background:new 0 0 255 255;" xml:space="preserve">


### PR DESCRIPTION
When using a custom `url` parameter for pages to override the path for a specific language for example, the current implementation of the language menu will show the wrong URL (with the most recent Hugo versions). Also, currently there will be and additional `/` in front of the language path parameter.

This PR fixes both. Tested with Hugo `0.59.1`.