### PR TITLE
fix select option color in Chrome

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1130,3 +1130,7 @@ pre .copy-to-clipboard:hover {
 #searchResults {
     text-align: left;
 }
+
+option {
+    color: initial;
+}


### PR DESCRIPTION
The current `nucleus.css` adds `color: inherit` for `<select>`. However, in Google Chrome, this also affects the `<option>` elements. Thus if the parent text color is white, then the option color will be white too, making the option text invisible against its default white background.

This PR simply adds a `color: initial` to the general `theme.css`.