### PR TITLE
Do not union on .menu.Sections (fixes #163)

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,7 +29,7 @@
                     {{ if .menu.IsHome}}
                         {{ $currentNode.Scratch.Set "pages" .menu.Sections }}
                     {{ else if .menu.Sections}}
-                        {{ $currentNode.Scratch.Set "pages" (.menu.Pages | union .menu.Sections) }}
+                        {{ $currentNode.Scratch.Set "pages" .menu.Pages }}
                     {{end}}
                     {{ $pages := ($currentNode.Scratch.Get "pages") }}
 


### PR DESCRIPTION
This should fix #163, which happens at least under Hugo `0.59.1`.