### PR TITLE
fix JavaScript error introduced in 3ea5bca

### DIFF
--- a/static/js/hugo-learn.js
+++ b/static/js/hugo-learn.js
@@ -22,11 +22,13 @@ var images = $("div#body-inner img").not(".inline");
 images.wrap(function(){
   var image =$(this);
   var o = getUrlParameter(image[0].src);
-  var f = o['featherlight'];
-  // IF featherlight is false, do not use feather light
-  if (f != 'false') {
-    if (!image.parent("a").length) {
-      return "<a href='" + image[0].src + "' data-featherlight='image'></a>";
+  if (typeof o !== "undefined") {
+    var f = o['featherlight'];
+    // IF featherlight is false, do not use feather light
+    if (f != 'false') {
+      if (!image.parent("a").length) {
+        return "<a href='" + image[0].src + "' data-featherlight='image'></a>";
+      }
     }
   }
 });


### PR DESCRIPTION
3ea5bca introduced a JavaScript error that occurs, if you add an image to the page _without_ any query parameters in the image URL. If no query parameters are present, then `getUrlParameter` will return `undefined`, which is checked for in pre-existing parts of the code, but not in the new part of the code. This PR fixes that by adding

```JavaScript
if (typeof o !== "undefined") {
    // …
}
```