### PR TITLE
Taxonomy list page header uses taxonomy name

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -91,7 +91,7 @@
           {{if and (not .IsHome) (not .Params.chapter) }}
             <h1>
               {{ if eq .Kind "taxonomy" }}
-                {{.Kind}} ::
+                {{.Data.Singular}} ::
               {{ end }}
               {{.Title}}
             </h1>


### PR DESCRIPTION
## What is new?
Previously taxonomy list pages had a title of `Taxonomy :: XXXX`.  This change replaces Taxonomy with the singular version of the Taxonomy type, for example `Tag :: XXXX`

## What does it look like?
![image](https://user-images.githubusercontent.com/1649564/77847048-0463fb00-71b2-11ea-9717-e251a6ea43c5.png)
