### PR TITLE
Updated theme installation documentation link.

### DIFF
--- a/exampleSite/content/basics/installation/_index.en.md
+++ b/exampleSite/content/basics/installation/_index.en.md
@@ -15,7 +15,7 @@ hugo new site <new_project>
 
 ## Install the theme
 
-Install the **Hugo-theme-learn** theme by following [this documentation](https://gohugo.io/themes/installing/)
+Install the **Hugo-theme-learn** theme by following [this documentation](https://gohugo.io/getting-started/quick-start/#step-3-add-a-theme)
 
 This theme's repository is: https://github.com/matcornic/hugo-theme-learn.git
 


### PR DESCRIPTION
Since the old link redirects to "Hugo Modules" documentation, which isn't fitting for this kind of theme, I changed it to the short tutorial in the getting started guide. Not perfect but better than having a mismatching guide, confusing users (such as myself).