### PR TITLE
Take search query from URL params

### DIFF
--- a/static/js/learn.js
+++ b/static/js/learn.js
@@ -173,6 +173,30 @@ jQuery(document).ready(function() {
         }
     }
 
+    // Define a url param parser
+    var getUrlParameter = function getUrlParameter(sParam) {
+        var sPageURL = window.location.search.substring(1),
+            sURLVariables = sPageURL.split('&'),
+            sParameterName,
+            i;
+
+        for (i = 0; i < sURLVariables.length; i++) {
+            sParameterName = sURLVariables[i].split('=');
+
+            if (sParameterName[0] === sParam) {
+                return sParameterName[1] === undefined ? true : decodeURIComponent(sParameterName[1]);
+            }
+        }
+    };
+
+    // Set the search input
+    jQuery('[data-search-input]').focus().val(getUrlParameter("q"));
+
+    // Simulate a keyup event for the autocomplete to render suggestions.
+    var e = $.Event('keyup');
+    e.which = 32;
+    jQuery('[data-search-input]').get(0).keyupHandler(e);
+
     // clipboard
     var clipInit = false;
     $('code').each(function() {


### PR DESCRIPTION
The search query can be taken from URL params if we simulate a single keyup to get the autocomplete to render suggestions.