### PR TITLE
Fix "type o is undefined" JS error

### DIFF
--- a/static/js/hugo-learn.js
+++ b/static/js/hugo-learn.js
@@ -22,11 +22,13 @@ var images = $("div#body-inner img").not(".inline");
 images.wrap(function(){
   var image =$(this);
   var o = getUrlParameter(image[0].src);
-  var f = o['featherlight'];
-  // IF featherlight is false, do not use feather light
-  if (f != 'false') {
-    if (!image.parent("a").length) {
-      return "<a href='" + image[0].src + "' data-featherlight='image'></a>";
+  if (typeof o !== "undefined") {
+    var f = o['featherlight'];
+    // IF featherlight is false, do not use feather light
+    if (f != 'false') {
+      if (!image.parent("a").length) {
+        return "<a href='" + image[0].src + "' data-featherlight='image'></a>";
+      }
     }
   }
 });


### PR DESCRIPTION
**hugo-learn.js/images.wrap(function()**) does not check 'o' for being undefined causing JS to exit on pages with images. This causes JS not to add copy-to-clipboard segments to headings on the pages with images. The fix is two-liner to check whether o is defined.