### PR TITLE
Remove .Inner from children shortcode

### DIFF
--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -35,8 +35,6 @@
 	{{end}}
 </ul>
 
-{{.Inner|safeHTML}}
-
 {{ define "childs" }}
 	{{ range .menu }}
 		{{ if and .Params.hidden (not $.showhidden) }}


### PR DESCRIPTION
The `children` shortcode shouldn't call `.Inner` as it doesn't have nested content. A consequence of calling `.Inner` is that Hugo takes the rest of the page as the inner content displaying it incorrectly.

See as an example: https://learn.netlify.app/en/shortcodes/children/
The page stops abruptly with `{{% children description="true" %}}` with the rest of the page content missing. While the HTML source shows `<!-- raw HTML omitted -->` in place of the missing content.