### PR TITLE
Remove page parameter for children shortcode

### DIFF
--- a/exampleSite/content/shortcodes/children/_index.en.md
+++ b/exampleSite/content/shortcodes/children/_index.en.md
@@ -9,7 +9,6 @@ Use the children shortcode to list the child pages of a page and the further des
 
 | Parameter | Default | Description |
 |:--|:--|:--|
-| page | _current_ | Specify the page name (section name) to display children for |
 | style | "li" | Choose the style used to display descendants. It could be any HTML tag name |
 | showhidden | "false" | When true, child pages hidden from the menu will be displayed |
 | description  | "false" | Allows you to include a short text under each page in the list.<br/>when no description exists for the page, children shortcode takes the first 70 words of your content. [read more info about summaries on gohugo.io](https://gohugo.io/content/summaries/)  |


### PR DESCRIPTION
The `page` parameter isn't actually supported. See https://github.com/matcornic/hugo-theme-learn/issues/170

Of course a PR implementing that parameter would be way better 😃, but I could not get it to work. In the mean time I think it should be removed from the documentation, to avoid confusion.