### PR TITLE
Remove code that adjusts navigation margin

### DIFF
--- a/static/js/learn.js
+++ b/static/js/learn.js
@@ -350,22 +350,6 @@ jQuery(document).ready(function() {
 });
 
 jQuery(window).on('load', function() {
-
-    function adjustForScrollbar() {
-        if ((parseInt(jQuery('#body-inner').height()) + 83) >= jQuery('#body').height()) {
-            jQuery('.nav.nav-next').css({ 'margin-right': getScrollBarWidth() });
-        } else {
-            jQuery('.nav.nav-next').css({ 'margin-right': 0 });
-        }
-    }
-
-    // adjust sidebar for scrollbar
-    adjustForScrollbar();
-
-    jQuery(window).smartresize(function() {
-        adjustForScrollbar();
-    });
-
     // store this page in session
     sessionStorage.setItem(jQuery('body').data('url'), 1);
 


### PR DESCRIPTION
Hi. Thanks for this beautiful theme. I however noticed something odd, which is that this `adjustForScrollbar` function does not seem to be doing anything under regular usage, but it is getting in my way when I try to customize my home page. I'll explain.

The code adds a ~15px margin to the right navigation arrow then the `#body-inner` height is near the same height as `#body`. The intent appears to be to detect when the scrollbar is present on-screen, but because `#body` is a div that contains `#body-inner`, and therefore content added to `#body-inner` affects the height  of both divs, this condition will continue to always evaluate to `false`. I checked this on pages that required scrolling, and sure enough the margin of the right-nav was still 0.

So for the above reason I believe the code can be removed, since it doesn't seem to be serving its intended purpose. Please let me know if I misevaluated the purpose.

The reason I came across this is that I am trying to customize my home page in a way that it creates a banner that is flush with the top of the page. In doing so I have removed the `83px` margin, which is now triggering this code to add a margin to the left nav, and it looks wrong.

<img width="231" alt="Screen Shot 2020-07-21 at 12 27 40 PM" src="https://user-images.githubusercontent.com/9969202/88097820-a33fa900-cb4d-11ea-88b0-36ae6aa96cae.png">
