### PR TITLE
Make the expand section more obvious

### DIFF
--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,14 +1,16 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class="expand">
-    <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
-        <i style="font-size:x-small;" class="fas fa-chevron-right"></i>
+    <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-angle-double-down' : 'fas fa-angle-double-right';});});">
+        <i style="font-size:xx-large;" class="fas fa-angle-double-right"></i>
         <span>
+        <b>
         {{$expandMessage := T "Expand-title"}}
     	{{ if .IsNamedParams }}
     	{{.Get "default" | default $expandMessage}}
     	{{else}}
     	{{.Get 0 | default $expandMessage}}
-    	{{end}}
+        {{end}}
+        </b>
     	</span>
     </div>
     <div class="expand-content" style="display: none;">

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -55,6 +55,12 @@ body #chapter h1 {
         font-size: 2rem;
     }
 }
+.expand-content {
+    padding-left: 30px;
+}
+.expand-label:hover {
+    color: #00bdf3;
+}
 a {
     color: #00bdf3;
 }


### PR DESCRIPTION
From the interface it's pretty non-obvious that the expand section can actually be... expanded.

I added the following changes:
- Add a mouse over to the title that's the same color as other links
- Make the icons bigger, use a double chevron
- Make the title bold
- Indent the content slightly after it's expanded

## Before (gif)

![before](https://user-images.githubusercontent.com/2030983/89744367-05ab0b80-da61-11ea-80e3-b5bbd75fd887.gif)

## After (gif)

![after](https://user-images.githubusercontent.com/2030983/89744368-080d6580-da61-11ea-8fc6-001a80d46532.gif)
