### PR TITLE
Make copy to clipboard button more obvious, make hover match link color

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1078,12 +1078,12 @@ pre .copy-to-clipboard {
     position: absolute;
     right: 4px;
     top: 4px;
-    background-color: #949bab;
+    background-color: #C1C4C6;
     color: #ccc;
     border-radius: 2px;
 }
 pre .copy-to-clipboard:hover {
-    background-color: #656c72;
+    background-color: #00bdf3;
     color: #fff;
 }
 .parent-element {


### PR DESCRIPTION
Make the "copy to clipboard" button more obvious by making the background a lighter color, and changing the hover image to match the color of the standard link hover color.

## Before
![before](https://user-images.githubusercontent.com/2030983/89744548-f88f1c00-da62-11ea-973f-93554fc8cbc0.gif)

## After
![after](https://user-images.githubusercontent.com/2030983/89744547-f75def00-da62-11ea-915e-e656dcaf6404.gif)
