### PR TITLE
Add a language label to code blocks

### DIFF
--- a/static/css/hugo-theme.css
+++ b/static/css/hugo-theme.css
@@ -1,5 +1,41 @@
 /* Insert here special css for hugo theme, on top of any other imported css */
 
+/* Language display style borrowed from scotch.io. Thanks! */
+pre {
+  border-radius: 10px;
+  border: none;
+  position: relative;
+  padding: 50px 40px 30px;
+  z-index: 1;
+}
+
+pre:after {
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 8px;
+  background: #ddd;
+}
+
+pre:before {
+  content: attr(data-title);
+  position: absolute;
+  top: 7px;
+  padding: 0 10px 3px;
+  font-size: 10px;
+  text-align: right;
+  color: #444;
+  font-weight: 700;
+  letter-spacing: .8px;
+  text-transform: uppercase;
+  border-radius: 0 0 5px 5px;
+  background: #ddd;
+}
 
 /* Table of contents */
 
@@ -250,5 +286,5 @@ figcaption h4 {
 }
 
 .is-sticky #top-bar {
-  box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.1); 
+  box-shadow: -1px 2px 5px 1px rgba(0, 0, 0, 0.1);
 }

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1077,8 +1077,8 @@ td {
 pre .copy-to-clipboard {
     position: absolute;
     right: 4px;
-    top: 4px;
-    background-color: #949bab;
+    top:10px;
+    background-color: #ddd;
     color: #ccc;
     border-radius: 2px;
 }

--- a/static/js/learn.js
+++ b/static/js/learn.js
@@ -1,3 +1,20 @@
+// Add a language label per each code block
+$("pre").each(function (i, e) {
+    // Intialize with empty value
+    $(e).attr("data-title", " ");
+});
+
+$("pre code").each(function (i, e) {
+    var code = $(e);
+    var pre = code.parent();
+
+    var html_class = code.attr('class')
+    var language = html_class ? html_class.replace('language-', '') : "text";
+    var text_block = pre.text();
+    
+    pre.attr("data-title", language);
+});
+
 // Scrollbar Width function
 function getScrollBarWidth() {
     var inner = document.createElement('p');


### PR DESCRIPTION
Add a language label to each individual code block, move the copy to clipboard button down to accommodate the new header

## Before

![image](https://user-images.githubusercontent.com/2030983/89745016-a8658900-da65-11ea-99df-1e6cba21ffb8.png)

## After

![image](https://user-images.githubusercontent.com/2030983/89745018-adc2d380-da65-11ea-8399-6c2494de24d7.png)


