### PR TITLE
fix: change taxonomy term and use taxonomy name

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,7 +4,7 @@
 	{{ .Content }}
 {{end}}
 
-{{ if or (eq .Kind "taxonomy") (eq .Kind "taxonomyTerm") }}
+{{ if or (eq .Kind "taxonomy") (eq .Kind "term") }}
 <ul>
 	{{ range .Pages }}
 		<li><a href="{{.RelPermalink}}">{{.Title}}</a></li>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -93,8 +93,8 @@
         <div id="body-inner">
           {{if and (not .IsHome) (not .Params.chapter) }}
             <h1>
-              {{ if eq .Kind "taxonomy" }}
-                {{.Kind}} ::
+              {{ if or (eq .Kind "taxonomy") (eq .Kind "term") }}
+                {{.Data.Singular}} ::
               {{ end }}
               {{.Title}}
             </h1>


### PR DESCRIPTION
without my fix, tags page are broken.
If you run `hugo serve`
 
There is no reference in page : 
<img width="1303" alt="Capture d’écran 2020-09-09 à 11 59 17" src="https://user-images.githubusercontent.com/30294729/92587004-58155d00-f297-11ea-8d52-582e98112820.png">

TaxonomyTerm is replace by term

see https://github.com/sjroe/hugo-theme-learn/commit/bf74d9e81c503ec24e44fccde449f58dfed259c9 #389 


