### PR TITLE
Fix mermaid code fences (#410)

### DIFF
--- a/exampleSite/content/shortcodes/mermaid.en.md
+++ b/exampleSite/content/shortcodes/mermaid.en.md
@@ -27,6 +27,26 @@ graph LR;
     C -->|Two| E[Result two]
 {{</mermaid>}}
 
+or you can use this alternative syntax:
+
+    ```mermaid
+    graph LR;
+        A[Hard edge] -->|Link text| B(Round edge)
+        B --> C{Decision}
+        C -->|One| D[Result one]
+        C -->|Two| E[Result two]
+    ```
+
+renders as
+
+```mermaid
+graph LR;
+    A[Hard edge] -->|Link text| B(Round edge)
+    B --> C{Decision}
+    C -->|One| D[Result one]
+    C -->|Two| E[Result two]
+```
+
 ## Sequence example
 
     {{</* mermaid */>}}

--- a/exampleSite/content/shortcodes/mermaid.fr.md
+++ b/exampleSite/content/shortcodes/mermaid.fr.md
@@ -26,6 +26,26 @@ graph LR;
     C -->|Deux| E[Résultat deux]
 {{< /mermaid >}}
 
+or you can use this alternative syntax:
+
+    ```mermaid
+    graph LR;
+        A[Bords droits] -->|Lien texte| B(Bords arondis)
+        B --> C{Décision}
+        C -->|Un| D[Résultat un]
+        C -->|Deux| E[Résultat deux]
+    ```
+
+renders as
+
+```mermaid
+graph LR;
+    A[Bords droits] -->|Lien texte| B(Bords arondis)
+    B --> C{Décision}
+    C -->|Un| D[Résultat un]
+    C -->|Deux| E[Résultat deux]
+```
+
 ## Sequence example
 
     {{</*mermaid*/>}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -75,7 +75,9 @@
             <script src="{{"mermaid/mermaid.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
         {{ end }}
         <script>
-            mermaid.initialize({ startOnLoad: true });
+            if (mermaid) {
+                mermaid.startOnLoad = false;
+            }
         </script>
     {{ end }}
     {{ partial "custom-footer.html" . }}

--- a/static/js/hugo-learn.js
+++ b/static/js/hugo-learn.js
@@ -87,8 +87,12 @@ jQuery(document).ready(function() {
       e.clearSelection();
       $(e.trigger).attr('aria-label', 'Link copied to clipboard!').addClass('tooltipped tooltipped-s');
   });
+
   $('code.language-mermaid').each(function(index, element) {
     var content = $(element).html().replace(/&amp;/g, '&');
     $(element).parent().replaceWith('<div class="mermaid" align="center">' + content + '</div>');
   });
+  if (mermaid) {
+    mermaid.init(undefined, $('.mermaid'));
+  }
 });


### PR DESCRIPTION
This PR restores the display of mermaid graphs using code fences - so called alternate syntax and fixing #410.

Both mermaid and hugo-learn are executing code in the browsers onLoad event. Because both executions aren't synced, display will fail if mermaids onLoad-handler is executed before hugo-learns onLoad-handler.

I observed this issue in latest FF on Windows but not in latest Chrome on Windows.

The solution of this PR should work reliably in all browsers.