### PR TITLE
Only highlight text in HTML elements (#235)

### DIFF
--- a/static/js/learn.js
+++ b/static/js/learn.js
@@ -370,7 +370,7 @@ $(function() {
 
 jQuery.extend({
     highlight: function(node, re, nodeName, className) {
-        if (node.nodeType === 3) {
+        if (node.nodeType === 3 && node.parentElement.namespaceURI == 'http://www.w3.org/1999/xhtml') { // text nodes
             var match = node.data.match(re);
             if (match) {
                 var highlight = document.createElement(nodeName || 'span');


### PR DESCRIPTION
Fixes #235.

Mermaid uses different techniques to generate text in graphs:
1. in a native svg element
2. in a svg foreignObject element that embedds html

Highlightning fails for the first case. This patch avoids highlighting text in those elements.
Highlightning for the second case is preserved with this patch.

For users this may be a bit suprising to sometimes see highlighted text in mermaid graphs and sometimes not.
