### PR TITLE
Rework notice boxes

### DIFF
--- a/exampleSite/content/shortcodes/notice.en.md
+++ b/exampleSite/content/shortcodes/notice.en.md
@@ -10,6 +10,8 @@ The notice shortcode shows 4 types of disclaimers to help you structure your pag
 ```
 {{%/* notice note */%}}
 A notice disclaimer
+
+A second paragraph in the disclaimer
 {{%/* /notice */%}}
 ```
 
@@ -17,6 +19,8 @@ renders as
 
 {{% notice note %}}
 A notice disclaimer
+
+A second paragraph in the disclaimer
 {{% /notice %}}
 
 ### Info

--- a/exampleSite/content/shortcodes/notice.fr.md
+++ b/exampleSite/content/shortcodes/notice.fr.md
@@ -10,12 +10,16 @@ Le shortcode *Notice* permet d'afficher 4 types de message pour vous aider à st
 ```
 {{%/* notice note */%}}
 Une notice de type *note*
+
+Une notice de type *note*
 {{%/* /notice */%}}
 ```
 
 s'affiche comme
 
 {{% notice note %}}
+Une notice de type *note*
+
 Une notice de type *note*
 {{% /notice %}}
 

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -24,3 +24,15 @@ other = "المزيد"
 
 [Expand-title]
 other = "...قم بتوسيع"
+
+[note]
+other = "Note"
+
+[info]
+other = "Info"
+
+[tip]
+other = "Tip"
+
+[warning]
+other = "Warning"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -24,3 +24,15 @@ other = "Mehr"
 
 [Expand-title]
 other = "Erweitere mich..."
+
+[note]
+other = "Anmerkung"
+
+[info]
+other = "Info"
+
+[tip]
+other = "Tipp"
+
+[warning]
+other = "Warnung"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -24,3 +24,15 @@ other = "More"
 
 [Expand-title]
 other = "Expand me..."
+
+[note]
+other = "Note"
+
+[info]
+other = "Info"
+
+[tip]
+other = "Tip"
+
+[warning]
+other = "Warning"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -24,3 +24,15 @@ other = "Más"
 
 [Expand-title]
 other = "Expandir..."
+
+[note]
+other = "Nota"
+
+[info]
+other = "Información"
+
+[tip]
+other = "Consejo"
+
+[warning]
+other = "Aviso"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -24,3 +24,15 @@ other = "Aller plus loin"
 
 [Expand-title]
 other = "Déroulez-moi..."
+
+[note]
+other = "Remarque"
+
+[info]
+other = "Information"
+
+[tip]
+other = "Astuce"
+
+[warning]
+other = "Avertissement"

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -24,3 +24,15 @@ other = "अधिक सामग्री दिखाएं"
 
 [Expand-title]
 other = "विस्तार करे..."
+
+[note]
+other = "Note"
+
+[info]
+other = "Info"
+
+[tip]
+other = "Tip"
+
+[warning]
+other = "Warning"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -24,3 +24,15 @@ other = "Lainnya"
 
 [Expand-title]
 other = "Bentangkan..."
+
+[note]
+other = "Note"
+
+[info]
+other = "Info"
+
+[tip]
+other = "Tip"
+
+[warning]
+other = "Warning"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -24,3 +24,15 @@ other = "更に"
 
 [Expand-title]
 other = "開く..."
+
+[note]
+other = "Note"
+
+[info]
+other = "Info"
+
+[tip]
+other = "Tip"
+
+[warning]
+other = "Warning"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -24,3 +24,15 @@ other = "Snelkoppelingen"
 
 [Expand-title]
 other = "Lees meer..."
+
+[note]
+other = "Note"
+
+[info]
+other = "Info"
+
+[tip]
+other = "Tip"
+
+[warning]
+other = "Warning"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -24,3 +24,15 @@ other = "Mais"
 
 [Expand-title]
 other = "Expandir..."
+
+[note]
+other = "Nota"
+
+[info]
+other = "Informação"
+
+[tip]
+other = "Dica"
+
+[warning]
+other = "Aviso"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -24,3 +24,15 @@ other = "Еще"
 
 [Expand-title]
 other = "Развернуть..."
+
+[note]
+other = "Заметка"
+
+[info]
+other = "Информация"
+
+[tip]
+other = "Совет"
+
+[warning]
+other = "Внимание"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -24,3 +24,15 @@ other = "Dahası Var"
 
 [Expand-title]
 other = "Genişlet..."
+
+[note]
+other = "Note"
+
+[info]
+other = "Info"
+
+[tip]
+other = "Tip"
+
+[warning]
+other = "Warning"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -24,3 +24,15 @@ other = "更多"
 
 [Expand-title]
 other = "展开"
+
+[note]
+other = "注释"
+
+[info]
+other = "信息"
+
+[tip]
+other = "提示"
+
+[warning]
+other = "警告"

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,2 +1,5 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>{{ .Inner }}</div>
+<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
+  <div class="label">{{ .Get 0 | T }}</div>
+  {{ .Inner }}
+</div>

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -505,28 +505,28 @@ div.notices > div.label:first-child:before {
     margin-right: .35rem;
 }
 div.notices.info {
-    border-top-color: #6AB0DE;
+    border-color: #6AB0DE;
     background: #E7F2FA;
 }
 div.notices.info > div.label:first-child:before {
     content: "\f05a";
 }
 div.notices.warning {
-    border-top-color: rgba(217, 83, 79, 0.8);
+    border-color: rgba(217, 83, 79, 0.8);
     background: #FAE2E2;
 }
 div.notices.warning > div.label:first-child:before {
     content: "\f071";
 }
 div.notices.note {
-    border-top-color: #F0B37E;
+    border-color: #F0B37E;
     background: #FFF2DB;
 }
 div.notices.note > div.label:first-child:before {
     content: "\f06a";
 }
 div.notices.tip {
-    border-top-color: rgba(92, 184, 92, 0.8);
+    border-color: rgba(92, 184, 92, 0.8);
     background: #E6F9E6;
 }
 div.notices.tip > div.label:first-child:before {

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -481,59 +481,56 @@ blockquote cite {
     font-size: 1.2rem;
 }
 div.notices {
-    margin: 2rem 0;
-    position: relative;
-}
-div.notices p {
-    padding: 15px;
-    display: block;
-    font-size: 1rem;
-    margin-top: 0rem;
-    margin-bottom: 0rem;
+    border-top-width: 2rem;
+    border-top-style: solid;
     color: #666;
+    margin: 2rem 0;
+    padding-bottom: .1px;
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
-div.notices p:first-child:before {
-    position: absolute;
-    top: 2px;
+div.notices > * {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+div.notices > div.label {
     color: #fff;
+    margin-bottom: 1rem;
+    margin-top: -1.75rem;
+}
+div.notices > div.label:first-child:before {
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
-    content: "\f06a";
-    left: 10px;
+    margin-left: -.35rem;
+    margin-right: .35rem;
 }
-div.notices p:first-child:after {
-    position: absolute;
-    top: 2px;
-    color: #fff;
-    left: 2rem;
-}
-div.notices.info p {
-    border-top: 30px solid #F0B37E;
-    background: #FFF2DB;
-}
-div.notices.info p:first-child:after {
-    content: 'Info';
-}
-div.notices.warning p {
-    border-top: 30px solid rgba(217, 83, 79, 0.8);
-    background: #FAE2E2;
-}
-div.notices.warning p:first-child:after {
-    content: 'Warning';
-}
-div.notices.note p {
-    border-top: 30px solid #6AB0DE;
+div.notices.info {
+    border-top-color: #6AB0DE;
     background: #E7F2FA;
 }
-div.notices.note p:first-child:after {
-    content: 'Note';
+div.notices.info > div.label:first-child:before {
+    content: "\f05a";
 }
-div.notices.tip p {
-    border-top: 30px solid rgba(92, 184, 92, 0.8);
+div.notices.warning {
+    border-top-color: rgba(217, 83, 79, 0.8);
+    background: #FAE2E2;
+}
+div.notices.warning > div.label:first-child:before {
+    content: "\f071";
+}
+div.notices.note {
+    border-top-color: #F0B37E;
+    background: #FFF2DB;
+}
+div.notices.note > div.label:first-child:before {
+    content: "\f06a";
+}
+div.notices.tip {
+    border-top-color: rgba(92, 184, 92, 0.8);
     background: #E6F9E6;
 }
-div.notices.tip p:first-child:after {
-    content: 'Tip';
+div.notices.tip > div.label:first-child:before {
+    content: "\f0eb";
 }
 
 /* attachments shortcode */


### PR DESCRIPTION
This patch includes the following:

- translatable labels (#334, #128)

  I grabbed translations from [here](https://github.com/martignoni/hugo-notice/tree/master/i18n). If not available, I put in the old english text. To all foreign speakers: Please review!
- multiple blocks in one box (#402, #152)

  Because I had to change the CSS for the first topic significantly, I also included this fix.
- usage of distinct icons for each type

  This is to improve readability for color blindness and on black/white printouts.
- switching colors for info and note

  This is because internationally the `i` symbol is usually associated with a blue background.

After rework, it is now easier for theme users to overwrite just the colors and icons of the notice boxes in their own CSS.