### PR TITLE
fix: add padding for h3 title in toc

### DIFF
--- a/static/css/hugo-theme.css
+++ b/static/css/hugo-theme.css
@@ -27,6 +27,8 @@
 
 #TableOfContents > ul > li > ul > li > a {
   font-weight: bold;
+  padding: 0 36px;
+  margin: 0 2px;
 }
 
 #TableOfContents > ul > li > ul > li > ul > li > ul > li > ul > li  {


### PR DESCRIPTION
There is wrong indentation in TOC for h3 menu.

We can see it [here](https://learn.netlify.app/en/cont/syntaxhighlight/#download-custom-highlightjs)

`download-custom-highlightjs` is a h3 title but rendered as h2 in TOC