### PR TITLE
Added binary prefix for kilobyte using i18n

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -24,3 +24,6 @@ other = "المزيد"
 
 [Expand-title]
 other = "...قم بتوسيع"
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -24,3 +24,6 @@ other = "Mehr"
 
 [Expand-title]
 other = "Erweitere mich..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -24,3 +24,6 @@ other = "More"
 
 [Expand-title]
 other = "Expand me..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -24,3 +24,6 @@ other = "Más"
 
 [Expand-title]
 other = "Expandir..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -24,3 +24,6 @@ other = "Aller plus loin"
 
 [Expand-title]
 other = "Déroulez-moi..."
+
+[BinaryPrefix-kilobyte]
+other = "ko"

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -24,3 +24,6 @@ other = "अधिक सामग्री दिखाएं"
 
 [Expand-title]
 other = "विस्तार करे..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -24,3 +24,6 @@ other = "Lainnya"
 
 [Expand-title]
 other = "Bentangkan..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -24,3 +24,6 @@ other = "更に"
 
 [Expand-title]
 other = "開く..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -24,3 +24,6 @@ other = "Snelkoppelingen"
 
 [Expand-title]
 other = "Lees meer..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -24,3 +24,6 @@ other = "Mais"
 
 [Expand-title]
 other = "Expandir..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -24,3 +24,6 @@ other = "Еще"
 
 [Expand-title]
 other = "Развернуть..."
+
+[BinaryPrefix-kilobyte]
+other = "килобайт"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -24,3 +24,6 @@ other = "Dahası Var"
 
 [Expand-title]
 other = "Genişlet..."
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -24,3 +24,6 @@ other = "更多"
 
 [Expand-title]
 other = "展开"
+
+[BinaryPrefix-kilobyte]
+other = "kb"

--- a/layouts/shortcodes/attachments.html
+++ b/layouts/shortcodes/attachments.html
@@ -18,7 +18,7 @@
 					<a href="{{ (printf "%s%s/%s" $fileDir ($.Scratch.Get "filesName") .Name) | relURL }}" >
 						{{.Name}}
 					</a>
-					({{div .Size 1024 }} ko)
+					({{div .Size 1024 }} {{T "BinaryPrefix-kilobyte"}})
 				</li>
 			{{end}}
 		{{else}}
@@ -26,7 +26,7 @@
 				<a href="{{ (printf "%s%s/%s" $fileDir ($.Scratch.Get "filesName") .Name) | relURL }}" >
 					{{.Name}}
 				</a>
-				({{div .Size 1024 }} ko)
+				({{div .Size 1024 }} {{T "BinaryPrefix-kilobyte"}})
 			</li>
 		{{end}}
 	{{end}}


### PR DESCRIPTION
This PR is for minor **i18n** fix with regards to the binary prefix as mentioned in PR #299 

Based on the suggestion there and the [link](https://mle2f.wordpress.com/2008/11/14/unites-binaires/), kilobyte binary prefix will be **"ko"** for **Fr** while **En** will be **"kb"**.