### PR TITLE
Switch from .files folder to page bundle for attachments shortcode

### DIFF
--- a/exampleSite/content/shortcodes/attachments.en.md
+++ b/exampleSite/content/shortcodes/attachments.en.md
@@ -9,25 +9,7 @@ The Attachments shortcode displays a list of files attached to a page.
 
 ## Usage
 
-The shortcurt lists files found in a **specific folder**.
-Currently, it support two implementations for pages
-
-1. If your page is a markdown file, attachements must be placed in a **folder** named like your page and ending with **.files**.
-
-    > * content
-    >   * _index.md
-    >   * page.files
-    >      * attachment.pdf
-    >   * page.md
-
-2. If your page is a **folder**, attachements must be placed in a nested **'files'** folder.
-
-    > * content
-    >   * _index.md
-    >   * page
-    >      * index.md
-    >      * files
-    >          * attachment.pdf
+The shortcurt lists files/resources found in [page bundle](https://gohugo.io/content-management/page-bundles/). 
 
 Be aware that if you use a multilingual website, you will need to have as many folders as languages.
 
@@ -39,23 +21,24 @@ That's all!
 |:--|:--|:--|
 | title | "Attachments" | List's title  |
 | style | "" | Choose between "orange", "grey", "blue" and "green" for nice style |
-| pattern | ".*" | A regular expressions, used to filter the attachments by file name. <br/><br/>The **pattern** parameter value must be [regular expressions](https://en.wikipedia.org/wiki/Regular_expression).
+| pattern | ".*" | A globbing pattern, used to filter the attachments by file name. <br/><br/>The **pattern** parameter value must be [glob pattern](https://github.com/gobwas/glob/blob/master/readme.md).
 
 For example:
 
-* To match a file suffix of 'jpg', use **.*jpg** (not *.jpg).
-* To match file names ending in 'jpg' or 'png', use **.*(jpg|png)**
+* To match a file suffix of 'jpg', use `*.jpg`.
+* To match file names ending in 'jpg' or 'png', use `*.{jpg,png}`
 
 ### Examples
 
 #### List of attachments ending in pdf or mp4
 
-
-    {{%/*attachments title="Related files" pattern=".*(pdf|mp4)"/*/%}}
+```
+{{%attachments title="Related files" pattern="*.{pdf,mp4}"/%}}
+```
 
 renders as
 
-{{%attachments title="Related files" pattern=".*(pdf|mp4)"/%}}
+{{%attachments title="Related files" pattern="*.{pdf,mp4}"/%}}
 
 #### Colored styled box
 

--- a/layouts/shortcodes/attachments.html
+++ b/layouts/shortcodes/attachments.html
@@ -4,33 +4,26 @@
 		<i class="fas fa-paperclip" aria-hidden="true"></i>
 		{{with .Get "title"}}{{.}}{{else}}{{T "Attachments-label"}}{{end}}
 	</label>
-	{{if eq .Page.File.BaseFileName "index"}}
-		{{$.Scratch.Add "filesName" "files"}}
-	{{else}}
-		{{$.Scratch.Add "filesName" (printf "%s.files" .Page.File.BaseFileName)}}
-	{{end}}
 	<div class="attachments-files">
-	{{ range (readDir (printf "./content/%s%s" .Page.File.Dir ($.Scratch.Get "filesName")) ) }}
-		{{ $fileDir := replace $.Page.File.Dir "\\" "/" }}
 		{{if ($.Get "pattern")}}
-			{{if (findRE ($.Get "pattern") .Name)}}
+			{{ range ($.Page.Resources.Match ($.Get "pattern")) }}
 				<li>
-					<a href="{{ (printf "%s%s/%s" $fileDir ($.Scratch.Get "filesName") .Name) | relURL }}" >
+					<a href="{{ .Permalink }}">
 						{{.Name}}
 					</a>
-					({{div .Size 1024 }} ko)
+					({{div ((os.Stat (.RelPermalink)).Size) 1024 }} kb)
 				</li>
 			{{end}}
 		{{else}}
-			<li>
-				<a href="{{ (printf "%s%s/%s" $fileDir ($.Scratch.Get "filesName") .Name) | relURL }}" >
-					{{.Name}}
-				</a>
-				({{div .Size 1024 }} ko)
-			</li>
+			{{ range ($.Page.Resources.Match "**") }}
+				<li>
+					<a href="{{ .Permalink }}">
+						{{.Name}}
+					</a>
+					({{div ((os.Stat (.RelPermalink)).Size) 1024 }} kb)
+				</li>
+			{{end}}
 		{{end}}
-	{{end}}
 	</div>
 	{{.Inner}}
 </section>
-


### PR DESCRIPTION
Changes how the `attachments` shortcode works. Now it uses Hugo's page bundles/resources instead of a custom implementation. 
 
Page bundle docs: https://gohugo.io/content-management/page-bundles/

https://github.com/matcornic/hugo-theme-learn/issues/387
https://github.com/matcornic/hugo-theme-learn/issues/100