### PR TITLE
add logic for wiki style links functionality

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,14 @@
 {{ partial "header.html" . }}
 
-{{ .Content }}
+{{$wikilinks := .Content | findRE "\\[\\[([^/]+)\\]\\]" }}
+{{$temp_content := $.Content}}
+{{range $wikilinks}} 
+    {{$page_title := . | strings.TrimPrefix "[[" | strings.TrimSuffix "]]" }}
+    {{range first 1 (where site.Pages "Params.title" $page_title)}}
+        {{$temp_content = ($temp_content | replaceRE (printf "\\[\\[%s\\]\\]" $page_title) (printf "<a href=\"%s\">[[%s]]</a>" .Permalink $page_title) )}}
+    {{end}}
+{{end}}
+{{$temp_content  | safeHTML}}
 
 <footer class="footline">
 	{{with .Params.LastModifierDisplayName}}


### PR DESCRIPTION
This adds a feature where you can link to any page in `site.Pages` by just using `[[page_you_want_to_link]]`. 

- It will use the first match it finds, so you cannot have pages with the same `Params.title`
- It might affect build performance if there is a huge number of pages and wikilinks

These types of links are getting more popular with tools like roam, foam, obsidian, etc.