### PR TITLE
Don't count hidden pages for the sub-menus

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -119,7 +119,7 @@
             <i class="fas fa-check read-icon"></i>
           {{ end }}
       </a>
-      {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
+      {{ $numberOfPages := (add (len ( where .Pages "Params.hidden" "ne" true )) (len ( where .Sections "Params.hidden" "ne" true ))) }}
       {{ if ne $numberOfPages 0 }}
         <ul>
           {{ $currentNode.Scratch.Set "pages" .Pages }}


### PR DESCRIPTION
Without this fix if you only have hidden pages in your sub-menu you will get an empty `<ul></ul>` that makes the menu entry a little bit taller than the others