### PR TITLE
Improve attachment size internationalization

### DIFF
--- a/exampleSite/content/shortcodes/attachments.en.files/small_file.txt
+++ b/exampleSite/content/shortcodes/attachments.en.files/small_file.txt
@@ -1,0 +1,1 @@
+This file was downloaded from Hugo Learn Theme.

--- a/exampleSite/content/shortcodes/attachments.en.md
+++ b/exampleSite/content/shortcodes/attachments.en.md
@@ -39,23 +39,23 @@ That's all!
 |:--|:--|:--|
 | title | "Attachments" | List's title  |
 | style | "" | Choose between "orange", "grey", "blue" and "green" for nice style |
-| pattern | ".*" | A regular expressions, used to filter the attachments by file name. <br/><br/>The **pattern** parameter value must be [regular expressions](https://en.wikipedia.org/wiki/Regular_expression).
+| pattern | ".*" | A regular expression, used to filter the attachments by file name. The **pattern** parameter value must be a [regular expression](https://en.wikipedia.org/wiki/Regular_expression). |
 
 For example:
 
-* To match a file suffix of 'jpg', use **.*jpg** (not *.jpg).
-* To match file names ending in 'jpg' or 'png', use **.*(jpg|png)**
+* To match a file suffix of '.jpg', use `.*\.jpg$` (not `*.jpg`).
+* To match file names ending in '.jpg' or '.png', use `.*\.(jpg|png)$`.
 
 ### Examples
 
 #### List of attachments ending in pdf or mp4
 
 
-    {{%/*attachments title="Related files" pattern=".*(pdf|mp4)"/*/%}}
+    {{%/*attachments title="Related files" pattern=".*\.(pdf|mp4)$"/*/%}}
 
 renders as
 
-{{%attachments title="Related files" pattern=".*(pdf|mp4)"/%}}
+{{%attachments title="Related files" pattern=".*\.(pdf|mp4)$"/%}}
 
 #### Colored styled box
 

--- a/exampleSite/content/shortcodes/attachments.fr.files/small_file.txt
+++ b/exampleSite/content/shortcodes/attachments.fr.files/small_file.txt
@@ -1,0 +1,1 @@
+Ce fichier a été téléchargé à partir du Hugo Learn Theme.

--- a/exampleSite/content/shortcodes/attachments.fr.md
+++ b/exampleSite/content/shortcodes/attachments.fr.md
@@ -39,23 +39,23 @@ C'est tout !
 |:--|:--|:--|
 | title | "Pièces jointes" | Titre de la liste  |
 | style | "" | Choisir entre "orange", "grey", "blue" et "green" pour un style plus sympa |
-| pattern | ".*" | Une expression régulière, utilisée pour filtrer les pièces jointes par leur nom de fichier. <br/><br/>Le paramètre **pattern** doit être une [expression régulière](https://en.wikipedia.org/wiki/Regular_expression).
+| pattern | ".*" | Une expression régulière, utilisée pour filtrer les pièces jointes par leur nom de fichier. Le paramètre **pattern** doit être une [expression régulière](https://en.wikipedia.org/wiki/Regular_expression). |
 
 Par exemple:
 
-* Pour trouver les fichiers avec le suffixe 'jpg', utilisez **.*jpg** (pas *.jpg).
-* Pour trouver les fichiers avec les suffixe 'jpg' ou 'png', utilisez **.*(jpg|png)**
+* Pour trouver les fichiers avec le suffixe '.jpg', utilisez `.*\.jpg$` (pas `*.jpg`).
+* Pour trouver les fichiers avec les suffixe '.jpg' ou '.png', utilisez `.*\.(jpg|png)$`.
 
 ### Exemples
 
 #### Lister les pièces jointes de type pdf ou mp4
 
 
-    {{%/*attachments title="Fichiers associés" pattern=".*(pdf|mp4)"/*/%}}
+    {{%/*attachments title="Fichiers associés" pattern=".*\.(pdf|mp4)$"/*/%}}
 
 s'affiche comme
 
-{{%attachments title="Fichiers associés" pattern=".*(pdf|mp4)"/%}}
+{{%attachments title="Fichiers associés" pattern=".*\.(pdf|mp4)$"/%}}
 
 #### Modifier le style
 

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -25,5 +25,11 @@ other = "المزيد"
 [Expand-title]
 other = "...قم بتوسيع"
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -25,5 +25,11 @@ other = "Mehr"
 [Expand-title]
 other = "Erweitere mich..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -25,5 +25,11 @@ other = "More"
 [Expand-title]
 other = "Expand me..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -25,5 +25,11 @@ other = "Más"
 [Expand-title]
 other = "Expandir..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -25,5 +25,11 @@ other = "Aller plus loin"
 [Expand-title]
 other = "Déroulez-moi..."
 
-[BinaryPrefix-kilobyte]
+[Byte-symbol]
+other = "o"
+
+[Kilobyte-symbol]
 other = "ko"
+
+[Megabyte-symbol]
+other = "Mo"

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -25,5 +25,11 @@ other = "अधिक सामग्री दिखाएं"
 [Expand-title]
 other = "विस्तार करे..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -25,5 +25,11 @@ other = "Lainnya"
 [Expand-title]
 other = "Bentangkan..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -25,5 +25,11 @@ other = "更に"
 [Expand-title]
 other = "開く..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -25,5 +25,11 @@ other = "Snelkoppelingen"
 [Expand-title]
 other = "Lees meer..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -25,5 +25,11 @@ other = "Mais"
 [Expand-title]
 other = "Expandir..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -25,5 +25,11 @@ other = "Еще"
 [Expand-title]
 other = "Развернуть..."
 
-[BinaryPrefix-kilobyte]
-other = "килобайт"
+[Byte-symbol]
+other = "Б"
+
+[Kilobyte-symbol]
+other = "КБ"
+
+[Megabyte-symbol]
+other = "МБ"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -25,5 +25,11 @@ other = "Dahası Var"
 [Expand-title]
 other = "Genişlet..."
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -25,5 +25,11 @@ other = "更多"
 [Expand-title]
 other = "展开"
 
-[BinaryPrefix-kilobyte]
-other = "kb"
+[Byte-symbol]
+other = "B"
+
+[Kilobyte-symbol]
+other = "KB"
+
+[Megabyte-symbol]
+other = "MB"

--- a/layouts/shortcodes/attachments.html
+++ b/layouts/shortcodes/attachments.html
@@ -1,36 +1,34 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
+{{ $_hugo_config := `{ "version": 1 }` -}}
 <section class="attachments {{ with .Get "style"}}{{.}}{{ end }}">
-	<label>
-		<i class="fas fa-paperclip" aria-hidden="true"></i>
-		{{with .Get "title"}}{{.}}{{else}}{{T "Attachments-label"}}{{end}}
-	</label>
-	{{if eq .Page.File.BaseFileName "index"}}
-		{{$.Scratch.Add "filesName" "files"}}
-	{{else}}
-		{{$.Scratch.Add "filesName" (printf "%s.files" .Page.File.BaseFileName)}}
-	{{end}}
-	<div class="attachments-files">
-	{{ range (readDir (printf "./content/%s%s" .Page.File.Dir ($.Scratch.Get "filesName")) ) }}
-		{{ $fileDir := replace $.Page.File.Dir "\\" "/" }}
-		{{if ($.Get "pattern")}}
-			{{if (findRE ($.Get "pattern") .Name)}}
-				<li>
-					<a href="{{ (printf "%s%s/%s" $fileDir ($.Scratch.Get "filesName") .Name) | relURL }}" >
-						{{.Name}}
-					</a>
-					({{div .Size 1024 }} {{T "BinaryPrefix-kilobyte"}})
-				</li>
-			{{end}}
-		{{else}}
-			<li>
-				<a href="{{ (printf "%s%s/%s" $fileDir ($.Scratch.Get "filesName") .Name) | relURL }}" >
-					{{.Name}}
-				</a>
-				({{div .Size 1024 }} {{T "BinaryPrefix-kilobyte"}})
-			</li>
-		{{end}}
-	{{end}}
-	</div>
-	{{.Inner}}
+  <label>
+    <i class="fas fa-paperclip" aria-hidden="true"></i>
+    {{with .Get "title"}}{{.}}{{else}}{{T "Attachments-label"}}{{end}}
+  </label>
+  <div class="attachments-files">
+  {{- $filesName := "files" }}
+  {{- if ne .Page.File.BaseFileName "index" }}
+    {{- $filesName = printf "%s.files" .Page.File.BaseFileName }}
+  {{- end}}
+  {{- $fileDir := replace .Page.File.Dir "\\" "/" }}
+  {{- $pattern := .Get "pattern" | default "" }}
+  {{- range (readDir (printf "content/%s%s" .Page.File.Dir $filesName) ) }}
+    {{- if findRE $pattern .Name}}
+      {{- $size := .Size }}
+      {{- $unit := "Byte" }}
+      {{- if ge $size 1024 }}
+        {{- $size = div $size 1024 }}
+        {{- $unit = "Kilobyte" }}
+      {{- end}}
+      {{- if ge $size 1024 }}
+        {{- $size = div $size 1024 }}
+        {{- $unit = "Megabyte" }}
+      {{- end}}
+    <li>
+      <a href="{{ (printf "%s%s/%s" $fileDir $filesName .Name) | relLangURL }}">{{.Name}}</a>
+      ({{$size}} {{T (print $unit "-symbol")}})
+    </li>
+    {{- end}}
+  {{- end}}
+  </div>
+  {{- .Inner}}
 </section>
-


### PR DESCRIPTION
This PR makes the size units used in attachments to adjust to the file size.

Currently, it looks like this:
* BachGavotteShort.mp3 (357 kb)
* Carroll_AliceAuPaysDesMerveilles.pdf (175 kb)
* adivorciarsetoca00cape.pdf (361 kb)
* big_file.mp4 (2463 kb)
* hugo.png (17 kb)
* movieselectricsheep-flock-244-32500-2.mp4 (340 kb)
* small_file.txt (0 kb)

&nbsp;

With this PR:
* BachGavotteShort.mp3 (357 KB)
* Carroll_AliceAuPaysDesMerveilles.pdf (175 KB)
* adivorciarsetoca00cape.pdf (361 KB)
* big_file.mp4 (2 MB)
* hugo.png (17 KB)
* movieselectricsheep-flock-244-32500-2.mp4 (340 KB)
* small_file.txt (48 B)
