### PR TITLE
Fix: customMermaidURL can be used in site config and frontmatter

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -67,9 +67,9 @@
     <script src="{{"js/learn.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
     <script src="{{"js/hugo-learn.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
     {{ if (or (and (ne .Params.disableMermaid nil) (not .Params.disableMermaid)) (not .Site.Params.disableMermaid)) }}
-        {{ if isset .Params "customMermaidURL" }}
+        {{ if isset .Params "custommermaidurl" }}
             <script src="{{ .Params.customMermaidURL }}"></script>
-        {{ else if isset .Site.Params "customMermaidURL" }}
+        {{ else if isset .Site.Params "custommermaidurl" }}
             <script src="{{ .Site.Params.customMermaidURL }}"></script>
         {{ else }}
             <script src="{{"mermaid/mermaid.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>


### PR DESCRIPTION
Change param name to lower case,
since all site-level configuration keys are stored as lower case.
According to official hugo documentation:
https://gohugo.io/functions/isset/

This allows loading custom mermaid.js using the config option,
as specified in https://learn.netlify.app/en/basics/configuration/