### PR TITLE
Update _index.en.md

### DIFF
--- a/exampleSite/content/basics/installation/_index.en.md
+++ b/exampleSite/content/basics/installation/_index.en.md
@@ -58,7 +58,7 @@ hugo new --kind chapter basics/_index.md
 
 By opening the given file, you should see the property `chapter=true` on top, meaning this page is a _chapter_.
 
-By default all chapters and pages are created as a draft. If you want to render these pages, remove the property `draft: true` from the metadata.
+By default all chapters and pages are created as a draft. If you want to render these pages, remove the property `draft: true` from the metadata in `archetypes/default.md`.
 
 ## Create your first content pages
 


### PR DESCRIPTION
The documentation did not state where exactly to change the property `draft: true` and upon search `archetypes/default.md` was the only instance of `draft: true` I found. So I think it would be good to add this to the documentation for new users.