### PR TITLE
Removed condition of site being multilingual for the landingPageURL...

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -14,7 +14,7 @@
     <section id="homelinks">
       <ul>
         <li>
-            <a class="padding" href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'>{{ safeHTML (cond (ne .Site.Params.landingPageName nil) .Site.Params.landingPageName "<i class='fas fa-home'></i> Home") }}</a>
+            <a class="padding" href='{{ (cond (ne .Site.Params.landingPageURL nil) .Site.Params.landingPageURL "/") }}'>{{ safeHTML (cond (ne .Site.Params.landingPageName nil) .Site.Params.landingPageName "<i class='fas fa-home'></i> Home") }}</a>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
**Removed condition of site being multilingual for the landingPageURL to be honoured**

This theme ignores the landingPageURL for the link on the Home Page if the site is not multilingual.
Currently in menu.html, it checks for the site to be multilingual at the same time that it checks for a landingPageURL to be set.
In my case (and the reason why I'm contributing this PR) I have a single-language site that is not hosted on "/", so I'd like to have a Home button that takes me to the actual home page of the generated site.

Thanks for all the great work in this theme. Hope this is a small improvement that can be added soon.