### PR TITLE
Avoid expanding submenus

### DIFF
--- a/exampleSite/content/basics/configuration/_index.en.md
+++ b/exampleSite/content/basics/configuration/_index.en.md
@@ -24,6 +24,10 @@ Note that some of these parameters are explained in details in other sections of
   showVisitedLinks = false
   # Disable search function. It will hide search bar
   disableSearch = false
+  # By default, the menu will show the entire tree for the current site.
+  # For sites with many subsites and pages, setting this option to true will
+  # limit the menu to the current page, its ancestors, and their children.
+  hideExtendedTree = false
   # Javascript and CSS cache are automatically busted when new version of site is generated.
   # Set this to true to disable this behavior (some proxies don't handle well this optimization)
   disableAssetsBusting = false

--- a/exampleSite/content/basics/configuration/_index.fr.md
+++ b/exampleSite/content/basics/configuration/_index.fr.md
@@ -24,6 +24,10 @@ Notez que certains de ces paramètres sont expliqués en détails dans d'autres 
   showVisitedLinks = false
   # Désactive la fonction de recherche. Une valeur à true cache la barre de recherche.
   disableSearch = false
+  # Par défaut, le menu affichera l'intégralité de l'arborescence du site actuel.
+  # Pour les sites comportant de nombreux sous-sites et pages, définir cette option 
+  # sur true limitera le menu à la page actuelle, à ses ancêtres et à leurs enfants.
+  hideExtendedTree = false
   # Par défaut, le cache Javascript et CSS est automatiquement vidé lorsqu'une nouvelle version du site est générée.
   # Utilisez ce paramètre lorsque vous voulez désactiver ce comportement (c'est parfois incompatible avec certains proxys)
   disableAssetsBusting = false

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -119,8 +119,9 @@
             <i class="fas fa-check read-icon"></i>
           {{ end }}
       </a>
-      {{ $numberOfPages := (add (len ( where .Pages "Params.hidden" "ne" true )) (len ( where .Sections "Params.hidden" "ne" true ))) }}
-      {{ if ne $numberOfPages 0 }}
+      {{ if or (not .Site.Params.hideExtendedTree) (.IsAncestor $currentNode) (eq .File.UniqueID $currentFileUniqueID) }}
+       {{ $numberOfPages := (add (len ( where .Pages "Params.hidden" "ne" true )) (len ( where .Sections "Params.hidden" "ne" true ))) }}
+       {{ if ne $numberOfPages 0 }}
         <ul>
           {{ $currentNode.Scratch.Set "pages" .Pages }}
           {{ if .Sections}}
@@ -144,6 +145,7 @@
           {{ end }}
         {{end}}
         </ul>
+       {{ end }}
       {{ end }}
     </li>
   {{else}}


### PR DESCRIPTION
The sidebar menu shows the entire site tree for the selected top level submenu. For sites with a lot of subsites and pages, this makes it much harder to navigate.

This adds a `hideExtendedTree` site parameters. When set to true, the side menu shows only the most relevant pages: the current page, its ancestors, and their children. The default behavior remains the same, so this modification will not change the behavior of existing pages.

### Before

This site has lots of subsites and pages that all show at once.

![Screen Shot 2024-06-15 at 7 42 21 PM](https://github.com/matcornic/hugo-theme-learn/assets/147933/6fc65646-04f8-4daa-a701-a4e5ce260d76)

### After

Once `hideExtendedTree = true` is added to the site parameters in the configuration, the menu is simplified to this.

![Screen Shot 2024-06-15 at 7 42 37 PM](https://github.com/matcornic/hugo-theme-learn/assets/147933/b5999089-6bd3-4294-9ee2-ff35b0b0decf)

There are at least two active issues asking for this behavior.

Fixes: #511, #88
